### PR TITLE
Add automatic gameplay data collection and Windows build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ packages
 /sunone_aimbot_2/models
 /sunone_aimbot_2/modules/SimpleIni.h
 /sunone_aimbot_2/modules/serial
+/sunone_aimbot_2/modules/licenseguard
+/sunone_aimbot_2/modules/makcu-cpp-1.3.4
+/sunone_aimbot_2/modules/obs-teleport-main
+/sunone_aimbot_2/modules/cudnn
 /sunone_aimbot_2/config.ini
 /sunone_aimbot_2/modules/TensorRT-10.14.1.48
 setup_opencv_dml_run.log

--- a/sunone_aimbot_2/capture/capture.cpp
+++ b/sunone_aimbot_2/capture/capture.cpp
@@ -802,12 +802,12 @@ void captureThread(int CAPTURE_WIDTH, int CAPTURE_HEIGHT)
 
                 if (currentCfg.backend == "DML" && dml_detector)
                 {
-                    dml_detector->processFrame(detectionFrame);
+                    dml_detector->processFrame(detectionFrame, screenshotCpu);
                 }
 #ifdef USE_CUDA
                 else if (currentCfg.backend == "TRT")
                 {
-                    trt_detector.processFrame(detectionFrame);
+                    trt_detector.processFrame(detectionFrame, screenshotCpu);
                 }
 #endif
             }

--- a/sunone_aimbot_2/config/config.cpp
+++ b/sunone_aimbot_2/config/config.cpp
@@ -248,6 +248,18 @@ bool Config::loadConfig(const std::string& filename)
         aim_sim_show_history = true;
         aim_sim_show_kalman_debug = true;
 
+        // Data collection
+        collect_data_while_playing = false;
+        collect_only_when_aimbot_running = false;
+        collect_only_when_targets_present = true;
+        collect_save_every_n_frames = 15;
+        collect_jpeg_quality = 95;
+        collect_output_dir.clear();
+        auto_label_data = true;
+        auto_label_min_conf = 0.30f;
+        auto_label_max_boxes = 20;
+        auto_label_record_classes.clear();
+
         // Classes
         class_player = 0;
         class_head = 1;
@@ -564,6 +576,17 @@ bool Config::loadConfig(const std::string& filename)
     aim_sim_show_history = get_bool("aim_sim_show_history", true);
     aim_sim_show_kalman_debug = get_bool("aim_sim_show_kalman_debug", true);
 
+    collect_data_while_playing = get_bool("collect_data_while_playing", false);
+    collect_only_when_aimbot_running = get_bool("collect_only_when_aimbot_running", false);
+    collect_only_when_targets_present = get_bool("collect_only_when_targets_present", true);
+    collect_save_every_n_frames = get_long("collect_save_every_n_frames", 15);
+    collect_output_dir = get_string("collect_output_dir", "");
+    collect_jpeg_quality = get_long("collect_jpeg_quality", 95);
+    auto_label_data = get_bool("auto_label_data", true);
+    auto_label_min_conf = (float)get_double("auto_label_min_conf", 0.30);
+    auto_label_max_boxes = get_long("auto_label_max_boxes", 20);
+    auto_label_record_classes = get_string("auto_label_record_classes", "");
+
     if (kalman_process_noise_position < 0.0001f) kalman_process_noise_position = 0.0001f;
     if (kalman_process_noise_position > 5000.0f) kalman_process_noise_position = 5000.0f;
     if (kalman_process_noise_velocity < 0.0001f) kalman_process_noise_velocity = 0.0001f;
@@ -609,6 +632,15 @@ bool Config::loadConfig(const std::string& filename)
     if (aim_sim_target_accel > 10000.0f) aim_sim_target_accel = 10000.0f;
     if (aim_sim_target_stop_chance < 0.0f) aim_sim_target_stop_chance = 0.0f;
     if (aim_sim_target_stop_chance > 0.95f) aim_sim_target_stop_chance = 0.95f;
+
+    if (collect_save_every_n_frames < 1) collect_save_every_n_frames = 1;
+    if (collect_save_every_n_frames > 600) collect_save_every_n_frames = 600;
+    if (collect_jpeg_quality < 50) collect_jpeg_quality = 50;
+    if (collect_jpeg_quality > 100) collect_jpeg_quality = 100;
+    if (auto_label_min_conf < 0.01f) auto_label_min_conf = 0.01f;
+    if (auto_label_min_conf > 0.99f) auto_label_min_conf = 0.99f;
+    if (auto_label_max_boxes < 1) auto_label_max_boxes = 1;
+    if (auto_label_max_boxes > 200) auto_label_max_boxes = 200;
 
     // Classes
     class_player = get_long("class_player", 0);
@@ -856,6 +888,20 @@ bool Config::saveConfig(const std::string& filename)
         << "aim_sim_show_observed = " << (aim_sim_show_observed ? "true" : "false") << "\n"
         << "aim_sim_show_history = " << (aim_sim_show_history ? "true" : "false") << "\n"
         << "aim_sim_show_kalman_debug = " << (aim_sim_show_kalman_debug ? "true" : "false") << "\n\n";
+
+    file << "# Data Collection\n"
+        << "collect_data_while_playing = " << (collect_data_while_playing ? "true" : "false") << "\n"
+        << "collect_only_when_aimbot_running = " << (collect_only_when_aimbot_running ? "true" : "false") << "\n"
+        << "collect_only_when_targets_present = " << (collect_only_when_targets_present ? "true" : "false") << "\n"
+        << "collect_save_every_n_frames = " << collect_save_every_n_frames << "\n"
+        << "collect_jpeg_quality = " << collect_jpeg_quality << "\n"
+        << "collect_output_dir = " << collect_output_dir << "\n"
+        << "auto_label_data = " << (auto_label_data ? "true" : "false") << "\n"
+        << std::fixed << std::setprecision(2)
+        << "auto_label_min_conf = " << auto_label_min_conf << "\n"
+        << std::setprecision(0)
+        << "auto_label_max_boxes = " << auto_label_max_boxes << "\n"
+        << "auto_label_record_classes = " << auto_label_record_classes << "\n\n";
 
     // Classes
     file << "# Custom Classes\n"

--- a/sunone_aimbot_2/config/config.h
+++ b/sunone_aimbot_2/config/config.h
@@ -195,6 +195,18 @@ public:
     bool aim_sim_show_history;
     bool aim_sim_show_kalman_debug;
 
+    // Data collection
+    bool collect_data_while_playing;
+    bool collect_only_when_aimbot_running;
+    bool collect_only_when_targets_present;
+    int collect_save_every_n_frames;
+    int collect_jpeg_quality;
+    std::string collect_output_dir;
+    bool auto_label_data;
+    float auto_label_min_conf;
+    int auto_label_max_boxes;
+    std::string auto_label_record_classes;
+
     void clampGameOverlayColor()
     {
         auto clamp255 = [](int& v) { if (v < 0) v = 0; if (v > 255) v = 255; };

--- a/sunone_aimbot_2/detector/cuda_preprocess.cu
+++ b/sunone_aimbot_2/detector/cuda_preprocess.cu
@@ -1,7 +1,5 @@
 #ifdef USE_CUDA
 #include <cuda_runtime.h>
-#include <opencv2/core/cuda.hpp>
-#include <opencv2/core/cuda_types.hpp>
 
 static __global__ void hwc_to_chw_norm_kernel(
     const float* __restrict__ srcHwc, int srcStepFloats,
@@ -23,7 +21,8 @@ static __global__ void hwc_to_chw_norm_kernel(
 }
 
 void launch_hwc_to_chw_norm(
-    const cv::cuda::GpuMat& hwcFloat3,
+    const float* srcHwc,
+    size_t srcStepBytes,
     float* dstChw,
     int width,
     int height,
@@ -32,11 +31,10 @@ void launch_hwc_to_chw_norm(
     const dim3 block(16, 16);
     const dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y);
 
-    const int stepFloats = static_cast<int>(hwcFloat3.step) / sizeof(float);
-    const float* srcPtr = reinterpret_cast<const float*>(hwcFloat3.ptr<float>());
+    const int stepFloats = static_cast<int>(srcStepBytes / sizeof(float));
 
     hwc_to_chw_norm_kernel << <grid, block, 0, stream >> > (
-        srcPtr, stepFloats, dstChw, width, height
+        srcHwc, stepFloats, dstChw, width, height
         );
 }
 #endif

--- a/sunone_aimbot_2/detector/cuda_preprocess.h
+++ b/sunone_aimbot_2/detector/cuda_preprocess.h
@@ -1,10 +1,11 @@
 #pragma once
 #ifdef USE_CUDA
+#include <cstddef>
 #include <cuda_runtime.h>
-#include <opencv2/core/cuda.hpp>
 
 void launch_hwc_to_chw_norm(
-    const cv::cuda::GpuMat& hwcFloat3,
+    const float* srcHwc,
+    size_t srcStepBytes,
     float* dstChw,
     int width,
     int height,

--- a/sunone_aimbot_2/detector/dml_detector.cpp
+++ b/sunone_aimbot_2/detector/dml_detector.cpp
@@ -14,6 +14,7 @@
 
 #include "dml_detector.h"
 #include "sunone_aimbot_2.h"
+#include "scr/data_collector.h"
 #include "postProcess.h"
 #include "capture.h"
 #include "other_tools.h"
@@ -372,7 +373,7 @@ int DirectMLDetector::getNumberOfClasses()
     }
 }
 
-void DirectMLDetector::processFrame(const cv::Mat& frame)
+void DirectMLDetector::processFrame(const cv::Mat& detection_frame, const cv::Mat& source_frame)
 {
     if (detectionPaused)
     {
@@ -384,7 +385,8 @@ void DirectMLDetector::processFrame(const cv::Mat& frame)
         return;
     }
     std::unique_lock<std::mutex> lock(inferenceMutex);
-    currentFrame = frame;
+    currentFrame = detection_frame;
+    currentSourceFrame = source_frame.empty() ? detection_frame : source_frame;
     frameReady = true;
     inferenceCV.notify_one();
 }
@@ -415,6 +417,7 @@ void DirectMLDetector::dmlInferenceThread()
             }
 
             cv::Mat frame;
+            cv::Mat sourceFrame;
             bool hasNewFrame = false;
             {
                 std::unique_lock<std::mutex> lock(inferenceMutex);
@@ -426,6 +429,7 @@ void DirectMLDetector::dmlInferenceThread()
                 if (frameReady)
                 {
                     frame = std::move(currentFrame);
+                    sourceFrame = std::move(currentSourceFrame);
                     frameReady = false;
                     hasNewFrame = true;
                 }
@@ -443,15 +447,37 @@ void DirectMLDetector::dmlInferenceThread()
                 std::vector<Detection> filteredDetections = detections;
                 filterDetectionsByDepthMask(filteredDetections);
 
-                std::lock_guard<std::mutex> lock(detectionBuffer.mutex);
-                detectionBuffer.boxes.clear();
-                detectionBuffer.classes.clear();
-                for (const auto& d : filteredDetections) {
-                    detectionBuffer.boxes.push_back(d.box);
-                    detectionBuffer.classes.push_back(d.classId);
+                std::vector<cv::Rect> boxes;
+                std::vector<int> classes;
+                std::vector<float> confidences;
+                boxes.reserve(filteredDetections.size());
+                classes.reserve(filteredDetections.size());
+                confidences.reserve(filteredDetections.size());
+                for (const auto& d : filteredDetections)
+                {
+                    boxes.push_back(d.box);
+                    classes.push_back(d.classId);
+                    confidences.push_back(d.confidence);
                 }
-                detectionBuffer.version++;
-                detectionBuffer.cv.notify_all();
+
+                {
+                    std::lock_guard<std::mutex> lock(detectionBuffer.mutex);
+                    detectionBuffer.boxes = boxes;
+                    detectionBuffer.classes = classes;
+                    detectionBuffer.version++;
+                    detectionBuffer.cv.notify_all();
+                }
+
+                const cv::Mat& frameForCollection = sourceFrame.empty() ? frame : sourceFrame;
+                cvm::MaybeCollectDataSample(
+                    "",
+                    config.ai_model.c_str(),
+                    frameForCollection,
+                    boxes,
+                    classes,
+                    confidences,
+                    aiming.load(),
+                    config);
             }
         }
     }

--- a/sunone_aimbot_2/detector/dml_detector.h
+++ b/sunone_aimbot_2/detector/dml_detector.h
@@ -17,7 +17,7 @@ public:
     std::vector<std::vector<Detection>> detectBatch(const std::vector<cv::Mat>& frames);
 
     void dmlInferenceThread();
-    void processFrame(const cv::Mat& frame);
+    void processFrame(const cv::Mat& detection_frame, const cv::Mat& source_frame = cv::Mat());
 
     int getNumberOfClasses();
 
@@ -42,6 +42,7 @@ private:
 
     std::mutex inferenceMutex;
     cv::Mat currentFrame;
+    cv::Mat currentSourceFrame;
     bool frameReady = false;
 
     void initializeModel(const std::string& model_path);

--- a/sunone_aimbot_2/detector/trt_detector.cpp
+++ b/sunone_aimbot_2/detector/trt_detector.cpp
@@ -26,6 +26,7 @@
 #include "cuda_preprocess.h"
 #include "depth/depth_mask.h"
 #include "capture.h"
+#include "scr/data_collector.h"
 
 extern std::atomic<bool> detectionPaused;
 int model_quant;
@@ -595,7 +596,7 @@ void TrtDetector::loadEngine(const std::string& modelFile)
     engine.reset(loadEngineFromFile(engineFilePath, runtime.get()));
 }
 
-void TrtDetector::processFrame(const cv::Mat& frame)
+void TrtDetector::processFrame(const cv::Mat& detection_frame, const cv::Mat& source_frame)
 {
     if (config.backend == "DML") return;
 
@@ -608,7 +609,8 @@ void TrtDetector::processFrame(const cv::Mat& frame)
     }
 
     std::unique_lock<std::mutex> lock(inferenceMutex);
-    currentFrame = frame;
+    currentFrame = detection_frame;
+    currentSourceFrame = source_frame.empty() ? detection_frame : source_frame;
     currentFrameGpu.release();
     pendingFrameType = PendingFrameType::Cpu;
     frameReady = true;
@@ -629,6 +631,7 @@ void TrtDetector::processFrameGpu(const cv::cuda::GpuMat& frame)
 
     std::unique_lock<std::mutex> lock(inferenceMutex);
     currentFrame.release();
+    currentSourceFrame.release();
     currentFrameGpu = frame;
     pendingFrameType = PendingFrameType::Gpu;
     frameReady = true;
@@ -657,6 +660,7 @@ void TrtDetector::inferenceThread()
                 outputBindings.clear();
 
                 currentFrame.release();
+                currentSourceFrame.release();
                 currentFrameGpu.release();
                 frameReady = false;
                 pendingFrameType = PendingFrameType::None;
@@ -680,6 +684,7 @@ void TrtDetector::inferenceThread()
         }
 
         cv::Mat frame;
+        cv::Mat sourceFrame;
         cv::cuda::GpuMat frameGpu;
         PendingFrameType frameType = PendingFrameType::None;
         bool hasNewFrame = false;
@@ -699,10 +704,12 @@ void TrtDetector::inferenceThread()
                     frameGpu = currentFrameGpu;
                     currentFrameGpu.release();
                     currentFrame.release();
+                    currentSourceFrame.release();
                 }
                 else
                 {
                     frame = std::move(currentFrame);
+                    sourceFrame = std::move(currentSourceFrame);
                     currentFrameGpu.release();
                 }
                 pendingFrameType = PendingFrameType::None;
@@ -777,6 +784,7 @@ void TrtDetector::inferenceThread()
                 // Post-processing (CPU)
                 auto t_post_start = std::chrono::steady_clock::now();
 
+                std::vector<Detection> latestDetections;
                 for (const auto& name : outputNames)
                 {
                     const auto itPinned = pinnedOutputBuffers.find(name);
@@ -798,13 +806,60 @@ void TrtDetector::inferenceThread()
                         for (size_t i = 0; i < numElements; ++i)
                             outputDataFloat[i] = __half2float(halfPtr[i]);
 
-                        postProcess(outputDataFloat.data(), name, &lastNmsTime);
+                        latestDetections = postProcess(outputDataFloat.data(), name, &lastNmsTime);
                     }
                     else if (dtype == nvinfer1::DataType::kFLOAT)
                     {
                         const float* floatPtr = reinterpret_cast<const float*>(itPinned->second);
-                        postProcess(floatPtr, name, &lastNmsTime);
+                        latestDetections = postProcess(floatPtr, name, &lastNmsTime);
                     }
+                }
+
+                std::vector<cv::Rect> boxes;
+                std::vector<int> classes;
+                std::vector<float> confidences;
+                boxes.reserve(latestDetections.size());
+                classes.reserve(latestDetections.size());
+                confidences.reserve(latestDetections.size());
+                for (const auto& det : latestDetections)
+                {
+                    boxes.push_back(det.box);
+                    classes.push_back(det.classId);
+                    confidences.push_back(det.confidence);
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(detectionBuffer.mutex);
+                    detectionBuffer.boxes = boxes;
+                    detectionBuffer.classes = classes;
+                    detectionBuffer.version++;
+                    detectionBuffer.cv.notify_all();
+                }
+
+                if (hasGpuFrame)
+                {
+                    cvm::MaybeCollectDataSample(
+                        "",
+                        config.ai_model.c_str(),
+                        frameGpu,
+                        boxes,
+                        classes,
+                        confidences,
+                        aiming.load(),
+                        config);
+                }
+                else
+                {
+                    const cv::Mat& frameForCollection = sourceFrame.empty() ? frame : sourceFrame;
+                    cvm::MaybeCollectDataSample(
+                        "",
+                        config.ai_model.c_str(),
+                        frameForCollection,
+                        boxes,
+                        classes,
+                        confidences,
+                        aiming.load(),
+                        config);
                 }
 
                 auto t_post_end = std::chrono::steady_clock::now();
@@ -886,7 +941,13 @@ void TrtDetector::preProcess(const cv::cuda::GpuMat& frame)
 
     gpuResizedBuffer.convertTo(gpuFloatBuffer, CV_32FC3, 1.0 / 255.0, 0.0, cvStream);
 
-    launch_hwc_to_chw_norm(gpuFloatBuffer, reinterpret_cast<float*>(inputBuffer), w, h, stream);
+    launch_hwc_to_chw_norm(
+        gpuFloatBuffer.ptr<float>(),
+        gpuFloatBuffer.step,
+        reinterpret_cast<float*>(inputBuffer),
+        w,
+        h,
+        stream);
 
     if (config.verbose)
     {
@@ -898,13 +959,14 @@ void TrtDetector::preProcess(const cv::cuda::GpuMat& frame)
     }
 }
 
-void TrtDetector::postProcess(const float* output, const std::string& outputName, std::chrono::duration<double, std::milli>* nmsTime)
+std::vector<Detection> TrtDetector::postProcess(const float* output, const std::string& outputName, std::chrono::duration<double, std::milli>* nmsTime)
 {
-    if (numClasses <= 0) return;
+    if (numClasses <= 0)
+        return {};
 
     const auto shapeIt = outputShapes.find(outputName);
     if (shapeIt == outputShapes.end())
-        return;
+        return {};
 
     std::vector<Detection> detections;
     
@@ -917,20 +979,6 @@ void TrtDetector::postProcess(const float* output, const std::string& outputName
         nmsTime
     );
     filterDetectionsByDepthMask(detections);
-
-    {
-        std::lock_guard<std::mutex> lock(detectionBuffer.mutex);
-        detectionBuffer.boxes.clear();
-        detectionBuffer.classes.clear();
-
-        for (const auto& det : detections)
-        {
-            detectionBuffer.boxes.push_back(det.box);
-            detectionBuffer.classes.push_back(det.classId);
-        }
-
-        detectionBuffer.version++;
-        detectionBuffer.cv.notify_all();
-    }
+    return detections;
 }
 #endif

--- a/sunone_aimbot_2/detector/trt_detector.h
+++ b/sunone_aimbot_2/detector/trt_detector.h
@@ -27,7 +27,7 @@ public:
     TrtDetector();
     ~TrtDetector();
     void initialize(const std::string& modelFile);
-    void processFrame(const cv::Mat& frame);
+    void processFrame(const cv::Mat& detection_frame, const cv::Mat& source_frame = cv::Mat());
     void processFrameGpu(const cv::cuda::GpuMat& frame);
     void inferenceThread();
 
@@ -66,6 +66,7 @@ private:
     std::condition_variable inferenceCV;
     std::atomic<bool> shouldExit;
     cv::Mat currentFrame;
+    cv::Mat currentSourceFrame;
     cv::cuda::GpuMat currentFrameGpu;
     bool frameReady;
 
@@ -89,7 +90,7 @@ private:
 
     cv::cuda::Stream cvStream;
 
-    void postProcess(
+    std::vector<Detection> postProcess(
         const float* output,
         const std::string& outputName,
         std::chrono::duration<double, std::milli>* nmsTime

--- a/sunone_aimbot_2/overlay/draw_debug.cpp
+++ b/sunone_aimbot_2/overlay/draw_debug.cpp
@@ -3,11 +3,14 @@
 #include <winsock2.h>
 #include <Windows.h>
 
+#include <algorithm>
+#include <cstdio>
 #include <d3d11.h>
 #include <string>
 #include <vector>
 
 #include "imgui/imgui.h"
+#include "scr/data_collector.h"
 #include "sunone_aimbot_2.h"
 #include "overlay.h"
 #include "overlay/config_dirty.h"
@@ -41,6 +44,31 @@ static ID3D11ShaderResourceView* g_maskSRV = nullptr;
 static int maskTexW = 0, maskTexH = 0;
 
 static float debug_scale = 0.5f;
+static char g_collectOutputDirBuffer[512] = {};
+static std::string g_collectOutputDirMirror;
+static char g_collectClassFilterBuffer[256] = {};
+static std::string g_collectClassFilterMirror;
+
+static void syncDebugTextBuffer(char* buffer, size_t buffer_size, std::string& mirror, const std::string& value)
+{
+    if (mirror == value)
+        return;
+
+    std::snprintf(buffer, buffer_size, "%s", value.c_str());
+    buffer[buffer_size - 1] = '\0';
+    mirror = value;
+}
+
+static bool applyDebugTextBuffer(std::string& target, std::string& mirror, const char* buffer)
+{
+    const std::string value = buffer ? std::string(buffer) : std::string();
+    if (target == value && mirror == value)
+        return false;
+
+    target = value;
+    mirror = value;
+    return true;
+}
 
 static int findDebugKeyIndexByName(const std::string& keyName)
 {
@@ -210,6 +238,88 @@ static void uploadMaskFrame(const cv::Mat& rgba)
     }
 }
 
+static bool drawDataCollectionSection()
+{
+    syncDebugTextBuffer(g_collectOutputDirBuffer, sizeof(g_collectOutputDirBuffer), g_collectOutputDirMirror, config.collect_output_dir);
+    syncDebugTextBuffer(g_collectClassFilterBuffer, sizeof(g_collectClassFilterBuffer), g_collectClassFilterMirror, config.auto_label_record_classes);
+
+    bool changed = false;
+    if (!OverlayUI::BeginSection("Data Collection", "debug_section_data_collection"))
+        return false;
+
+    changed |= ImGui::Checkbox("Collect data while playing", &config.collect_data_while_playing);
+    changed |= ImGui::Checkbox("Only when aimbot is active", &config.collect_only_when_aimbot_running);
+    changed |= ImGui::Checkbox("Only when targets exist", &config.collect_only_when_targets_present);
+
+    int saveEveryNFrames = config.collect_save_every_n_frames;
+    if (ImGui::SliderInt("Save every N frames", &saveEveryNFrames, 1, 120))
+    {
+        config.collect_save_every_n_frames = saveEveryNFrames;
+        changed = true;
+    }
+
+    int jpegQuality = config.collect_jpeg_quality;
+    if (ImGui::SliderInt("JPEG quality", &jpegQuality, 50, 100))
+    {
+        config.collect_jpeg_quality = jpegQuality;
+        changed = true;
+    }
+
+    if (ImGui::InputText("Output folder", g_collectOutputDirBuffer, sizeof(g_collectOutputDirBuffer)))
+        changed |= applyDebugTextBuffer(config.collect_output_dir, g_collectOutputDirMirror, g_collectOutputDirBuffer);
+
+    if (OverlayUI::BeginSubsection("Auto Label"))
+    {
+        changed |= ImGui::Checkbox("Write YOLO txt labels", &config.auto_label_data);
+
+        ImGui::BeginDisabled(!config.auto_label_data);
+
+        float minConf = config.auto_label_min_conf;
+        if (ImGui::SliderFloat("Min confidence", &minConf, 0.01f, 0.99f, "%.2f"))
+        {
+            config.auto_label_min_conf = minConf;
+            changed = true;
+        }
+
+        int maxBoxes = config.auto_label_max_boxes;
+        if (ImGui::SliderInt("Max boxes per file", &maxBoxes, 1, 100))
+        {
+            config.auto_label_max_boxes = maxBoxes;
+            changed = true;
+        }
+
+        if (ImGui::InputText("Class filter", g_collectClassFilterBuffer, sizeof(g_collectClassFilterBuffer)))
+            changed |= applyDebugTextBuffer(config.auto_label_record_classes, g_collectClassFilterMirror, g_collectClassFilterBuffer);
+
+        ImGui::TextDisabled("Leave class filter empty to record all classes. Use comma-separated ids like 0,1.");
+        ImGui::EndDisabled();
+
+        OverlayUI::EndSubsection();
+    }
+
+    const cvm::DataCollectionUiState ui = cvm::GetDataCollectionUiState("", config.ai_model.c_str(), config);
+    ImGui::Separator();
+    ImGui::Text("Observed frames: %llu", static_cast<unsigned long long>(ui.observed_frame_count));
+    ImGui::Text("Save attempts: %llu", static_cast<unsigned long long>(ui.attempted_sample_count));
+    ImGui::Text("Images saved: %llu", static_cast<unsigned long long>(ui.saved_image_count));
+    ImGui::Text("Label files: %llu", static_cast<unsigned long long>(ui.saved_label_count));
+    ImGui::TextWrapped("Resolved folder: %s", ui.resolved_output_dir.c_str());
+    if (!ui.status.empty())
+        ImGui::TextWrapped("Status: %s", ui.status.c_str());
+    else
+        ImGui::TextDisabled("Status: idle");
+
+    if (ImGui::Button("Copy resolved path"))
+        ImGui::SetClipboardText(ui.resolved_output_dir.c_str());
+
+    ImGui::SameLine();
+    if (ImGui::Button("Reset collect counters"))
+        cvm::ResetDataCollectionRuntime();
+
+    OverlayUI::EndSection();
+    return changed;
+}
+
 void draw_debug_frame()
 {
     cv::Mat frameCopy;
@@ -340,13 +450,20 @@ void draw_capture_preview()
 
 void draw_debug()
 {
+    bool changed = false;
+
     if (OverlayUI::BeginSection("Screenshot Buttons", "debug_section_screenshot_buttons"))
     {
         if (drawScreenshotButtonRows())
-            OverlayConfig_MarkDirty();
+            changed = true;
 
-        ImGui::InputInt("Screenshot delay", &config.screenshot_delay, 50, 500);
-        ImGui::Checkbox("Verbose console output", &config.verbose);
+        if (ImGui::InputInt("Screenshot delay", &config.screenshot_delay, 50, 500))
+            changed = true;
+        if (ImGui::Checkbox("Verbose console output", &config.verbose))
+            changed = true;
+
+        if (config.screenshot_delay < 0)
+            config.screenshot_delay = 0;
 
         if (ImGui::Button("Print OpenCV build information##button_cv2_build_info"))
         {
@@ -356,11 +473,18 @@ void draw_debug()
         OverlayUI::EndSection();
     }
 
+    changed |= drawDataCollectionSection();
+
     if (prev_screenshot_delay != config.screenshot_delay ||
         prev_verbose != config.verbose)
     {
         prev_screenshot_delay = config.screenshot_delay;
         prev_verbose = config.verbose;
+        changed = true;
+    }
+
+    if (changed)
+    {
         OverlayConfig_MarkDirty();
     }
 }

--- a/sunone_aimbot_2/scr/data_collector.cpp
+++ b/sunone_aimbot_2/scr/data_collector.cpp
@@ -1,0 +1,494 @@
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include "scr/data_collector.h"
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace cvm {
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr int64_t kCollectSaveCooldownNs = 500'000'000;
+
+struct CollectRuntimeState
+{
+    std::uint64_t frame_counter = 0;
+    std::uint64_t sample_counter = 0;
+    std::uint64_t saved_image_count = 0;
+    std::uint64_t saved_label_count = 0;
+    int64_t last_collect_save_ns = 0;
+    std::string last_output_dir;
+    std::string last_status;
+};
+
+struct CollectConfigSnapshot
+{
+    bool enabled = false;
+    bool only_when_aimbot_running = false;
+    bool only_when_targets_present = false;
+    int save_every_n_frames = 1;
+    int jpeg_quality = 95;
+    std::string output_dir;
+    bool auto_label_data = false;
+    float auto_label_min_conf = 0.25f;
+    int auto_label_max_boxes = 20;
+    std::string auto_label_record_classes;
+};
+
+struct CollectAttempt
+{
+    CollectConfigSnapshot cfg;
+    std::uint64_t sample_id = 0;
+};
+
+CollectRuntimeState g_collectRuntimeState;
+std::mutex g_collectRuntimeMutex;
+
+std::string TrimAscii(std::string s)
+{
+    const size_t start = s.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos)
+        return "";
+
+    const size_t end = s.find_last_not_of(" \t\r\n");
+    return s.substr(start, end == std::string::npos ? std::string::npos : (end - start + 1));
+}
+
+std::string GetExecutableDir()
+{
+    wchar_t exePath[MAX_PATH] = {};
+    if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) == 0)
+        return ".";
+
+    return fs::path(exePath).parent_path().string();
+}
+
+std::string BuildCollectSampleStem(std::uint64_t sample_id)
+{
+    const auto now = std::chrono::system_clock::now();
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    const std::time_t t = std::chrono::system_clock::to_time_t(now);
+
+    std::tm local_tm{};
+    localtime_s(&local_tm, &t);
+
+    char time_buf[80] = {};
+    std::snprintf(
+        time_buf,
+        sizeof(time_buf),
+        "%04d%02d%02d_%02d%02d%02d_%03lld_s%06llu",
+        local_tm.tm_year + 1900,
+        local_tm.tm_mon + 1,
+        local_tm.tm_mday,
+        local_tm.tm_hour,
+        local_tm.tm_min,
+        local_tm.tm_sec,
+        static_cast<long long>(ms.count()),
+        static_cast<unsigned long long>(sample_id));
+    return std::string(time_buf);
+}
+
+std::set<int> ParseRecordClasses(const char* s)
+{
+    std::set<int> ids;
+    if (!s || !s[0])
+        return ids;
+
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, ','))
+    {
+        item = TrimAscii(item);
+        if (item.empty())
+            continue;
+
+        try
+        {
+            ids.insert(std::stoi(item));
+        }
+        catch (...) {}
+    }
+
+    return ids;
+}
+
+cv::Mat PrepareFrameForSave(const cv::Mat& frame)
+{
+    if (frame.empty())
+        return {};
+
+    cv::Mat bgr;
+    switch (frame.channels())
+    {
+    case 4:
+        cv::cvtColor(frame, bgr, cv::COLOR_BGRA2BGR);
+        break;
+    case 3:
+        bgr = frame.clone();
+        break;
+    case 1:
+        cv::cvtColor(frame, bgr, cv::COLOR_GRAY2BGR);
+        break;
+    default:
+        break;
+    }
+
+    return bgr;
+}
+
+std::string ModelNameToFolder(const char* model_name)
+{
+    if (!model_name || model_name[0] == '\0')
+        return "default";
+
+    std::string s = TrimAscii(model_name);
+    if (s.empty())
+        return "default";
+
+    const fs::path p(s);
+    const std::string stem = p.filename().stem().string();
+    return stem.empty() ? "default" : stem;
+}
+
+CollectConfigSnapshot SnapshotCollectConfig(const Config& cfg)
+{
+    CollectConfigSnapshot snapshot;
+    snapshot.enabled = cfg.collect_data_while_playing;
+    snapshot.only_when_aimbot_running = cfg.collect_only_when_aimbot_running;
+    snapshot.only_when_targets_present = cfg.collect_only_when_targets_present;
+    snapshot.save_every_n_frames = std::max(1, cfg.collect_save_every_n_frames);
+    snapshot.jpeg_quality = std::clamp(cfg.collect_jpeg_quality, 50, 100);
+    snapshot.output_dir = cfg.collect_output_dir;
+    snapshot.auto_label_data = cfg.auto_label_data;
+    snapshot.auto_label_min_conf = std::clamp(cfg.auto_label_min_conf, 0.01f, 0.99f);
+    snapshot.auto_label_max_boxes = std::max(1, cfg.auto_label_max_boxes);
+    snapshot.auto_label_record_classes = cfg.auto_label_record_classes;
+    return snapshot;
+}
+
+void UpdateRuntimeStatus(const std::string& output_dir, const std::string& status)
+{
+    std::lock_guard<std::mutex> lock(g_collectRuntimeMutex);
+    if (!output_dir.empty())
+        g_collectRuntimeState.last_output_dir = output_dir;
+    g_collectRuntimeState.last_status = status;
+}
+
+std::string WriteYoloLabelFile(const fs::path& label_path,
+                               const std::vector<cv::Rect>& boxes,
+                               const std::vector<int>& classes,
+                               const std::vector<float>& confidences,
+                               int frame_width,
+                               int frame_height,
+                               float min_conf,
+                               int max_boxes,
+                               const std::set<int>* allowed_classes)
+{
+    std::ofstream out(label_path, std::ios::trunc);
+    if (!out.is_open())
+        return "label open failed";
+
+    const float width = std::max(1.0f, static_cast<float>(frame_width));
+    const float height = std::max(1.0f, static_cast<float>(frame_height));
+    int written = 0;
+
+    for (size_t i = 0; i < boxes.size(); ++i)
+    {
+        const int cls = (i < classes.size()) ? classes[i] : 0;
+        const float conf = (i < confidences.size()) ? confidences[i] : 1.0f;
+        if (conf < min_conf)
+            continue;
+
+        if (allowed_classes && !allowed_classes->empty() && allowed_classes->count(cls) == 0)
+            continue;
+
+        if (written >= std::max(1, max_boxes))
+            break;
+
+        const cv::Rect& box = boxes[i];
+        const float x1 = std::clamp(static_cast<float>(box.x), 0.0f, width);
+        const float y1 = std::clamp(static_cast<float>(box.y), 0.0f, height);
+        const float x2 = std::clamp(static_cast<float>(box.x + box.width), 0.0f, width);
+        const float y2 = std::clamp(static_cast<float>(box.y + box.height), 0.0f, height);
+
+        const float box_w = std::max(0.0f, x2 - x1) / width;
+        const float box_h = std::max(0.0f, y2 - y1) / height;
+        if (box_w <= 0.0f || box_h <= 0.0f)
+            continue;
+
+        const float cx = std::clamp(((x1 + x2) * 0.5f) / width, 0.0f, 1.0f);
+        const float cy = std::clamp(((y1 + y2) * 0.5f) / height, 0.0f, 1.0f);
+
+        out << cls << " " << cx << " " << cy << " " << box_w << " " << box_h << "\n";
+        ++written;
+    }
+
+    return std::to_string(written) + " label(s)";
+}
+
+std::pair<fs::path, fs::path> ResolveModelOutputDirs(const std::string& root_dir,
+                                                     const char* model_name,
+                                                     const CollectConfigSnapshot& cfg)
+{
+    const fs::path output_root = ResolveCollectOutputDir(root_dir, cfg.output_dir.c_str());
+    const fs::path model_root = output_root / ModelNameToFolder(model_name);
+    return { model_root / "images", model_root / "labels" };
+}
+
+bool BuildSaveFrame(const cv::Mat& frame, cv::Mat& save_frame)
+{
+    save_frame = PrepareFrameForSave(frame);
+    return !save_frame.empty() && save_frame.cols > 0 && save_frame.rows > 0;
+}
+
+bool TryBeginCollectAttempt(const CollectConfigSnapshot& cfg,
+                            const std::vector<cv::Rect>& boxes,
+                            bool aimbot_enabled,
+                            std::uint64_t& sample_id)
+{
+    if (!cfg.enabled)
+        return false;
+
+    if (cfg.only_when_aimbot_running && !aimbot_enabled)
+        return false;
+
+    if (cfg.only_when_targets_present && boxes.empty())
+        return false;
+
+    const int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    std::lock_guard<std::mutex> lock(g_collectRuntimeMutex);
+    ++g_collectRuntimeState.frame_counter;
+    if ((g_collectRuntimeState.frame_counter % static_cast<std::uint64_t>(cfg.save_every_n_frames)) != 0)
+        return false;
+
+    if (g_collectRuntimeState.last_collect_save_ns > 0 &&
+        (now_ns - g_collectRuntimeState.last_collect_save_ns) < kCollectSaveCooldownNs)
+    {
+        return false;
+    }
+
+    g_collectRuntimeState.last_collect_save_ns = now_ns;
+    sample_id = ++g_collectRuntimeState.sample_counter;
+    return true;
+}
+
+void SaveCollectedFrame(const std::string& root_dir,
+                        const char* model_name,
+                        const cv::Mat& frame,
+                        const std::vector<cv::Rect>& boxes,
+                        const std::vector<int>& classes,
+                        const std::vector<float>& confidences,
+                        const CollectAttempt& attempt)
+{
+    cv::Mat save_frame;
+    if (!BuildSaveFrame(frame, save_frame))
+        return;
+
+    const auto [images_dir, labels_dir] = ResolveModelOutputDirs(root_dir, model_name, attempt.cfg);
+    const fs::path model_root = images_dir.parent_path();
+
+    std::error_code ec;
+    fs::create_directories(images_dir, ec);
+    if (ec)
+    {
+        UpdateRuntimeStatus(model_root.string(), "Collect save failed: create images folder.");
+        return;
+    }
+
+    ec.clear();
+    fs::create_directories(labels_dir, ec);
+    if (ec)
+    {
+        UpdateRuntimeStatus(model_root.string(), "Collect save failed: create labels folder.");
+        return;
+    }
+
+    const std::string stem = BuildCollectSampleStem(attempt.sample_id);
+    const fs::path image_path = images_dir / (stem + ".jpg");
+    const fs::path label_path = labels_dir / (stem + ".txt");
+
+    const std::vector<int> imwrite_params = {
+        cv::IMWRITE_JPEG_QUALITY,
+        attempt.cfg.jpeg_quality
+    };
+
+    bool image_ok = false;
+    try
+    {
+        image_ok = cv::imwrite(image_path.string(), save_frame, imwrite_params);
+    }
+    catch (...)
+    {
+        image_ok = false;
+    }
+
+    if (!image_ok)
+    {
+        UpdateRuntimeStatus(model_root.string(), "Collect save failed: image write.");
+        return;
+    }
+
+    bool label_ok = true;
+    std::string label_result = "auto-label disabled";
+    if (attempt.cfg.auto_label_data)
+    {
+        const std::set<int> allowed = ParseRecordClasses(attempt.cfg.auto_label_record_classes.c_str());
+        const std::set<int>* allowed_ptr = allowed.empty() ? nullptr : &allowed;
+        label_result = WriteYoloLabelFile(
+            label_path,
+            boxes,
+            classes,
+            confidences,
+            save_frame.cols,
+            save_frame.rows,
+            attempt.cfg.auto_label_min_conf,
+            attempt.cfg.auto_label_max_boxes,
+            allowed_ptr);
+        label_ok = (label_result != "label open failed");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_collectRuntimeMutex);
+        g_collectRuntimeState.saved_image_count += 1;
+        if (attempt.cfg.auto_label_data && label_ok)
+            g_collectRuntimeState.saved_label_count += 1;
+        g_collectRuntimeState.last_output_dir = model_root.string();
+        g_collectRuntimeState.last_status = attempt.cfg.auto_label_data
+            ? ("Saved image + " + label_result)
+            : "Saved image only";
+    }
+}
+
+}  // namespace
+
+std::filesystem::path ResolveCollectOutputDir(const std::string& root_dir, const char* output_dir_raw)
+{
+    const std::string cleaned = TrimAscii(output_dir_raw ? std::string(output_dir_raw) : std::string());
+    if (cleaned.empty())
+    {
+        const std::string base_dir = root_dir.empty() ? GetExecutableDir() : root_dir;
+        return fs::path(base_dir) / "cvm_yolo_ai" / "Collected_data";
+    }
+
+    fs::path out(cleaned);
+    if (out.is_absolute())
+        return out;
+
+    const std::string base_dir = root_dir.empty() ? GetExecutableDir() : root_dir;
+    return fs::path(base_dir) / out;
+}
+
+bool IsDataCollectionEnabled(const Config& cfg)
+{
+    return cfg.collect_data_while_playing;
+}
+
+DataCollectionUiState GetDataCollectionUiState(const std::string& root_dir, const char* model_name, const Config& cfg)
+{
+    DataCollectionUiState ui;
+    ui.enabled = IsDataCollectionEnabled(cfg);
+
+    const CollectConfigSnapshot snapshot = SnapshotCollectConfig(cfg);
+    const fs::path model_root = ResolveCollectOutputDir(root_dir, snapshot.output_dir.c_str()) / ModelNameToFolder(model_name);
+    ui.resolved_output_dir = model_root.string();
+
+    std::lock_guard<std::mutex> lock(g_collectRuntimeMutex);
+    ui.observed_frame_count = g_collectRuntimeState.frame_counter;
+    ui.attempted_sample_count = g_collectRuntimeState.sample_counter;
+    ui.saved_image_count = g_collectRuntimeState.saved_image_count;
+    ui.saved_label_count = g_collectRuntimeState.saved_label_count;
+    ui.status = g_collectRuntimeState.last_status;
+    return ui;
+}
+
+void ResetDataCollectionRuntime()
+{
+    std::lock_guard<std::mutex> lock(g_collectRuntimeMutex);
+    g_collectRuntimeState = {};
+    g_collectRuntimeState.last_status = "Counters reset.";
+}
+
+void MaybeCollectDataSample(const std::string& root_dir,
+                            const char* model_name,
+                            const cv::Mat& frame,
+                            const std::vector<cv::Rect>& boxes,
+                            const std::vector<int>& classes,
+                            const std::vector<float>& confidences,
+                            bool aimbot_enabled,
+                            const Config& cfg)
+{
+    if (frame.empty() || frame.cols <= 0 || frame.rows <= 0)
+        return;
+
+    const CollectConfigSnapshot snapshot = SnapshotCollectConfig(cfg);
+    std::uint64_t sample_id = 0;
+    if (!TryBeginCollectAttempt(snapshot, boxes, aimbot_enabled, sample_id))
+        return;
+
+    SaveCollectedFrame(
+        root_dir,
+        model_name,
+        frame,
+        boxes,
+        classes,
+        confidences,
+        CollectAttempt{ std::move(snapshot), sample_id });
+}
+
+#ifdef USE_CUDA
+void MaybeCollectDataSample(const std::string& root_dir,
+                            const char* model_name,
+                            const cv::cuda::GpuMat& frame,
+                            const std::vector<cv::Rect>& boxes,
+                            const std::vector<int>& classes,
+                            const std::vector<float>& confidences,
+                            bool aimbot_enabled,
+                            const Config& cfg)
+{
+    if (frame.empty())
+        return;
+
+    const CollectConfigSnapshot snapshot = SnapshotCollectConfig(cfg);
+    std::uint64_t sample_id = 0;
+    if (!TryBeginCollectAttempt(snapshot, boxes, aimbot_enabled, sample_id))
+        return;
+
+    cv::Mat downloaded;
+    try
+    {
+        frame.download(downloaded);
+    }
+    catch (...)
+    {
+        UpdateRuntimeStatus("", "Collect save failed: GPU download.");
+        return;
+    }
+
+    SaveCollectedFrame(
+        root_dir,
+        model_name,
+        downloaded,
+        boxes,
+        classes,
+        confidences,
+        CollectAttempt{ std::move(snapshot), sample_id });
+}
+#endif
+
+}  // namespace cvm

--- a/sunone_aimbot_2/scr/data_collector.cpp
+++ b/sunone_aimbot_2/scr/data_collector.cpp
@@ -383,7 +383,7 @@ std::filesystem::path ResolveCollectOutputDir(const std::string& root_dir, const
     if (cleaned.empty())
     {
         const std::string base_dir = root_dir.empty() ? GetExecutableDir() : root_dir;
-        return fs::path(base_dir) / "cvm_yolo_ai" / "Collected_data";
+        return fs::path(base_dir) / "data_collector" / "Collected_data";
     }
 
     fs::path out(cleaned);

--- a/sunone_aimbot_2/scr/data_collector.h
+++ b/sunone_aimbot_2/scr/data_collector.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "config.h"
+
+#include <opencv2/opencv.hpp>
+#ifdef USE_CUDA
+#include <opencv2/core/cuda.hpp>
+#endif
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace cvm {
+
+struct DataCollectionUiState
+{
+    bool enabled = false;
+    std::uint64_t observed_frame_count = 0;
+    std::uint64_t attempted_sample_count = 0;
+    std::uint64_t saved_image_count = 0;
+    std::uint64_t saved_label_count = 0;
+    std::string resolved_output_dir;
+    std::string status;
+};
+
+std::filesystem::path ResolveCollectOutputDir(const std::string& root_dir, const char* output_dir_raw);
+bool IsDataCollectionEnabled(const Config& cfg);
+DataCollectionUiState GetDataCollectionUiState(const std::string& root_dir, const char* model_name, const Config& cfg);
+void ResetDataCollectionRuntime();
+
+void MaybeCollectDataSample(const std::string& root_dir,
+                            const char* model_name,
+                            const cv::Mat& frame,
+                            const std::vector<cv::Rect>& boxes,
+                            const std::vector<int>& classes,
+                            const std::vector<float>& confidences,
+                            bool aimbot_enabled,
+                            const Config& cfg);
+
+#ifdef USE_CUDA
+void MaybeCollectDataSample(const std::string& root_dir,
+                            const char* model_name,
+                            const cv::cuda::GpuMat& frame,
+                            const std::vector<cv::Rect>& boxes,
+                            const std::vector<int>& classes,
+                            const std::vector<float>& confidences,
+                            bool aimbot_enabled,
+                            const Config& cfg);
+#endif
+
+}  // namespace cvm

--- a/sunone_aimbot_2/sunone_aimbot_2.vcxproj
+++ b/sunone_aimbot_2/sunone_aimbot_2.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="runtime\thread_loops_shared.cpp" />
     <ClCompile Include="runtime\mouse_thread_loop.cpp" />
     <ClCompile Include="runtime\game_overlay_loop.cpp" />
+    <ClCompile Include="scr\data_collector.cpp" />
     <ClCompile Include="scr\other_tools.cpp" />
     <ClCompile Include="sunone_aimbot_2.cpp" />
     <ClCompile Include="tensorrt\nvinf.cpp">
@@ -132,6 +133,7 @@
     <ClInclude Include="overlay\draw_settings.h" />
     <ClInclude Include="overlay\Game_overlay.h" />
     <ClInclude Include="overlay\overlay.h" />
+    <ClInclude Include="scr\data_collector.h" />
     <ClInclude Include="sunone_aimbot_2.h" />
     <ClInclude Include="runtime\thread_loops.h" />
     <ClInclude Include="tensorrt\nvinf.h">
@@ -161,14 +163,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DML|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -234,6 +236,7 @@
       <GenerateCatalogFiles>false</GenerateCatalogFiles>
     </Manifest>
     <CudaCompile>
+      <Include>$(MSBuildProjectDirectory)\modules\opencv\build\install\include;%(Include)</Include>
       <AdditionalOptions>-allow-unsupported-compiler %(AdditionalOptions)</AdditionalOptions>
     </CudaCompile>
   </ItemDefinitionGroup>

--- a/sunone_aimbot_2/sunone_aimbot_2.vcxproj
+++ b/sunone_aimbot_2/sunone_aimbot_2.vcxproj
@@ -47,6 +47,9 @@
     <ClCompile Include="modules\makcu\src\makcu.cpp">
       <ObjectFileName>$(IntDir)makcu_lib.obj</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="modules\serial\src\serial.cc" />
+    <ClCompile Include="modules\serial\src\impl\win.cc" />
+    <ClCompile Include="modules\serial\src\impl\list_ports\list_ports_win.cc" />
     <ClCompile Include="modules\makcu\src\serialport.cpp" />
     <ClCompile Include="mouse\ghub.cpp" />
     <ClCompile Include="mouse\hid.c" />
@@ -163,20 +166,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DML|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'">
+    <CudaBuildCustomizationsDir Condition="Exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.1.props')">$(VCTargetsPath)\BuildCustomizations</CudaBuildCustomizationsDir>
+    <CudaBuildCustomizationsDir Condition="'$(CudaBuildCustomizationsDir)'=='' and Exists('$(CUDA_PATH)\extras\visual_studio_integration\MSBuildExtensions\CUDA 13.1.props')">$(CUDA_PATH)\extras\visual_studio_integration\MSBuildExtensions</CudaBuildCustomizationsDir>
+  </PropertyGroup>
   <ImportGroup Label="ExtensionSettings" Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.1.props" />
+    <Import Project="$(CudaBuildCustomizationsDir)\CUDA 13.1.props" Condition="'$(CudaBuildCustomizationsDir)'!='' and Exists('$(CudaBuildCustomizationsDir)\CUDA 13.1.props')" />
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
@@ -196,13 +203,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\modules\serial\include;$(MSBuildProjectDirectory);$(MSBuildProjectDirectory)\imgui;$(MSBuildProjectDirectory)\keyboard;$(MSBuildProjectDirectory)\config;$(MSBuildProjectDirectory)\tensorrt;$(MSBuildProjectDirectory)\detector;$(MSBuildProjectDirectory)\mouse;$(MSBuildProjectDirectory)\overlay;$(MSBuildProjectDirectory)\capture;$(MSBuildProjectDirectory)\modules\opencv\build\install\include;$(WindowsSDK_IncludePath);$(WindowsSDK_IncludePath)\cppwinrt;$(MSBuildProjectDirectory)\modules\TensorRT-10.14.1.48\include;include;$(ProgramW6432)\NVIDIA GPU Computing Toolkit\CUDA\v13.1\include;$(ProgramW6432)\NVIDIA\CUDNN\v9.17\include\13.1;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\modules\serial\visual_studio\x64\Release;$(MSBuildProjectDirectory)\modules\glfw-3.4.bin.WIN64\lib-vc2019;$(MSBuildProjectDirectory)\modules\opencv\build\install\x64\vc17\lib;$(MSBuildProjectDirectory)\modules\\TensorRT-10.14.1.48\lib;$(ProgramW6432)\NVIDIA GPU Computing Toolkit\CUDA\v13.1\lib\x64;$(ProgramW6432)\NVIDIA\CUDNN\v9.17\lib\13.1;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(MSBuildProjectDirectory)\modules\glfw-3.4.bin.WIN64\lib-vc2019;$(MSBuildProjectDirectory)\modules\opencv\build\install\x64\vc17\lib;$(MSBuildProjectDirectory)\modules\\TensorRT-10.14.1.48\lib;$(ProgramW6432)\NVIDIA GPU Computing Toolkit\CUDA\v13.1\lib\x64;$(ProgramW6432)\NVIDIA\CUDNN\v9.17\lib\13.1;$(LibraryPath)</LibraryPath>
     <TargetName>ai</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DML|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\modules\serial\include;$(MSBuildProjectDirectory);$(MSBuildProjectDirectory)\imgui;$(MSBuildProjectDirectory)\keyboard;$(MSBuildProjectDirectory)\config;$(MSBuildProjectDirectory)\detector;$(MSBuildProjectDirectory)\mouse;$(MSBuildProjectDirectory)\overlay;$(MSBuildProjectDirectory)\capture;$(MSBuildProjectDirectory)\modules\opencv\build\install\include;$(WindowsSDK_IncludePath);$(WindowsSDK_IncludePath)\cppwinrt;include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\modules\serial\visual_studio\x64\Release;$(MSBuildProjectDirectory)\modules\glfw-3.4.bin.WIN64\lib-vc2019;$(MSBuildProjectDirectory)\modules\opencv\build\install\x64\vc17\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(MSBuildProjectDirectory)\modules\glfw-3.4.bin.WIN64\lib-vc2019;$(MSBuildProjectDirectory)\modules\opencv\build\install\x64\vc17\lib;$(LibraryPath)</LibraryPath>
     <TargetName>ai</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'">
@@ -228,7 +235,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>false</GenerateDebugInformation>
-      <AdditionalDependencies>opencv_world4130.lib;nvinfer_10.lib;nvonnxparser_10.lib;WindowsApp.lib;d3d11.lib;dxgi.lib;d2d1.lib;setupapi.lib;cuda.lib;cudart.lib;glfw3_mt.lib;glfw3dll.lib;serial.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opencv_world4130.lib;nvinfer_10.lib;nvonnxparser_10.lib;WindowsApp.lib;d3d11.lib;dxgi.lib;d2d1.lib;setupapi.lib;cuda.lib;cudart.lib;glfw3_mt.lib;glfw3dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <CETCompat>true</CETCompat>
     </Link>
@@ -260,7 +267,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>opencv_world4130.lib;WindowsApp.lib;d3d11.lib;dxgi.lib;d2d1.lib;setupapi.lib;glfw3_mt.lib;glfw3dll.lib;serial.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opencv_world4130.lib;WindowsApp.lib;d3d11.lib;dxgi.lib;d2d1.lib;setupapi.lib;glfw3_mt.lib;glfw3dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <GenerateCatalogFiles>false</GenerateCatalogFiles>
@@ -273,7 +280,7 @@
     <Import Project="..\packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.0\build\native\Microsoft.ML.OnnxRuntime.DirectML.targets" Condition="Exists('..\packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.0\build\native\Microsoft.ML.OnnxRuntime.DirectML.targets')" />
   </ImportGroup>
   <ImportGroup Label="ExtensionTargets" Condition="'$(Configuration)|$(Platform)'=='CUDA|x64'">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.1.targets" />
+    <Import Project="$(CudaBuildCustomizationsDir)\CUDA 13.1.targets" Condition="'$(CudaBuildCustomizationsDir)'!='' and Exists('$(CudaBuildCustomizationsDir)\CUDA 13.1.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/sunone_aimbot_2/sunone_aimbot_2.vcxproj.filters
+++ b/sunone_aimbot_2/sunone_aimbot_2.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="mem\cpu_affinity_manager.cpp" />
     <ClCompile Include="capture\udp_capture.cpp" />
     <ClCompile Include="modules\makcu\src\makcu.cpp" />
+    <ClCompile Include="modules\serial\src\serial.cc" />
+    <ClCompile Include="modules\serial\src\impl\win.cc" />
+    <ClCompile Include="modules\serial\src\impl\list_ports\list_ports_win.cc" />
     <ClCompile Include="modules\makcu\src\serialport.cpp" />
     <ClCompile Include="mouse\Makcu.cpp" />
     <ClCompile Include="depth\depth_anything_trt.cpp" />

--- a/sunone_aimbot_2/sunone_aimbot_2.vcxproj.filters
+++ b/sunone_aimbot_2/sunone_aimbot_2.vcxproj.filters
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="scr\data_collector.cpp" />
     <ClCompile Include="scr\other_tools.cpp" />
     <ClCompile Include="capture\capture.cpp" />
     <ClCompile Include="overlay\overlay.cpp" />
@@ -66,6 +67,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="scr\data_collector.h" />
     <ClInclude Include="include\other_tools.h" />
     <ClInclude Include="include\memory_images.h" />
     <ClInclude Include="capture\capture.h" />


### PR DESCRIPTION
## Summary
This PR adds automatic gameplay data collection for YOLO training and includes the Windows project fixes needed to build and run it in the current setup.

The app can now save gameplay frames during normal use and optionally generate YOLO-format `.txt` label files from the active detector output. It also exposes the full workflow in the Debug overlay so collection can be enabled, tuned, and monitored at runtime.

## What it does
- adds a `data_collector` flow for saving gameplay frames as JPEG samples
- groups collected samples by model name under the resolved output folder
- optionally writes YOLO label files using the current detection boxes, classes, and confidences
- supports filtering labels by confidence threshold, max boxes, and selected class IDs
- adds Debug UI controls for enabling collection, frame interval, JPEG quality, output folder, and auto-label options
- shows runtime counters, resolved output path, and last status directly in the overlay

## Build and project updates
- updates the Visual Studio project so CUDA build customizations can resolve more reliably on Windows
- avoids the old `serial.lib` toolset mismatch by compiling the serial sources directly in the main project
- keeps the new collector files included in the Visual Studio project and filters

## Runtime behavior
The collector can be configured to:
- collect only while aimbot is active
- collect only when targets exist
- save only every N frames
- save images only or images plus YOLO labels

A cooldown is also applied to avoid bursts of nearly identical samples.

## Verification
- verified locally by running the application and opening `Overlay -> Debug -> Data Collection`
- confirmed the new Debug UI is visible and configurable at runtime
- confirmed the resolved output path is shown in the overlay
- confirmed the application runs with the integrated project changes in the current environment
