### PR TITLE
Crosshair Feature,  Re-integrated Console Toggle, Advanced Recoil, Dynamic FOV

### DIFF
--- a/sunone_aimbot_2/config/config.cpp
+++ b/sunone_aimbot_2/config/config.cpp
@@ -70,10 +70,20 @@ bool Config::loadConfig(const std::string& filename)
         disable_headshot = false;
         body_y_offset = 0.15f;
         head_y_offset = 0.05f;
+        body_x_offset = 0.50f;
         auto_aim = false;
+        ignore_third_person = false;
+        shooting_range_targets = false;
 
         fovX = 106;
         fovY = 74;
+        enable_dynamic_fov = true;
+        fovX_hipfire = 50;
+        fovY_hipfire = 50;
+        fovX_ads = 30;
+        fovY_ads = 30;
+        hipfire_smooth = 1.0f;
+        
         minSpeedMultiplier = 0.1f;
         maxSpeedMultiplier = 0.1f;
 
@@ -377,10 +387,20 @@ bool Config::loadConfig(const std::string& filename)
     disable_headshot = get_bool("disable_headshot", false);
     body_y_offset = (float)get_double("body_y_offset", 0.15);
     head_y_offset = (float)get_double("head_y_offset", 0.05);
+    body_x_offset = (float)get_double("body_x_offset", 0.50);
     auto_aim = get_bool("auto_aim", false);
+    ignore_third_person = get_bool("ignore_third_person", false);
+    shooting_range_targets = get_bool("shooting_range_targets", false);
 
     fovX = get_long("fovX", 106);
     fovY = get_long("fovY", 74);
+    enable_dynamic_fov = get_bool("enable_dynamic_fov", true);
+    fovX_hipfire = get_long("fovX_hipfire", 50);
+    fovY_hipfire = get_long("fovY_hipfire", 50);
+    fovX_ads = get_long("fovX_ads", 30);
+    fovY_ads = get_long("fovY_ads", 30);
+    hipfire_smooth = (float)get_double("hipfire_smooth", 1.0);
+    
     minSpeedMultiplier = (float)get_double("minSpeedMultiplier", 0.1);
     maxSpeedMultiplier = (float)get_double("maxSpeedMultiplier", 0.1);
 
@@ -666,11 +686,20 @@ bool Config::saveConfig(const std::string& filename)
         << std::fixed << std::setprecision(2)
         << "body_y_offset = " << body_y_offset << "\n"
         << "head_y_offset = " << head_y_offset << "\n"
-        << "auto_aim = " << (auto_aim ? "true" : "false") << "\n\n";
+        << "body_x_offset = " << body_x_offset << "\n"
+        << "auto_aim = " << (auto_aim ? "true" : "false") << "\n"
+        << "ignore_third_person = " << (ignore_third_person ? "true" : "false") << "\n"
+        << "shooting_range_targets = " << (shooting_range_targets ? "true" : "false") << "\n\n";
 
     file << "# Mouse move\n"
         << "fovX = " << fovX << "\n"
         << "fovY = " << fovY << "\n"
+        << "enable_dynamic_fov = " << (enable_dynamic_fov ? "true" : "false") << "\n"
+        << "fovX_hipfire = " << fovX_hipfire << "\n"
+        << "fovY_hipfire = " << fovY_hipfire << "\n"
+        << "fovX_ads = " << fovX_ads << "\n"
+        << "fovY_ads = " << fovY_ads << "\n"
+        << std::fixed << std::setprecision(2) << "hipfire_smooth = " << hipfire_smooth << "\n"
         << "minSpeedMultiplier = " << minSpeedMultiplier << "\n"
         << "maxSpeedMultiplier = " << maxSpeedMultiplier << "\n"
         << std::fixed << std::setprecision(2)

--- a/sunone_aimbot_2/config/config.cpp
+++ b/sunone_aimbot_2/config/config.cpp
@@ -98,6 +98,15 @@ bool Config::loadConfig(const std::string& filename)
 
         easynorecoil = false;
         easynorecoilstrength = 0.0f;
+        
+        recoil_pull_down_strength = 0.0f;
+        recoil_pull_left_strength = 0.0f;
+        recoil_pull_left_delay = 200.0f;
+        recoil_pull_right_strength = 0.0f;
+        recoil_pull_right_delay = 200.0f;
+        recoil_sway_speed = 12.0f;
+        recoil_sway = 2.0f;
+
         input_method = "WIN32";
 
         wind_mouse_enabled = false;
@@ -396,6 +405,15 @@ bool Config::loadConfig(const std::string& filename)
 
     easynorecoil = get_bool("easynorecoil", false);
     easynorecoilstrength = (float)get_double("easynorecoilstrength", 0.0);
+    
+    recoil_pull_down_strength = (float)get_double("recoil_pull_down_strength", 0.0);
+    recoil_pull_left_strength = (float)get_double("recoil_pull_left_strength", 0.0);
+    recoil_pull_left_delay = (float)get_double("recoil_pull_left_delay", 200.0);
+    recoil_pull_right_strength = (float)get_double("recoil_pull_right_strength", 0.0);
+    recoil_pull_right_delay = (float)get_double("recoil_pull_right_delay", 200.0);
+    recoil_sway_speed = (float)get_double("recoil_sway_speed", 12.0);
+    recoil_sway = (float)get_double("recoil_sway", 2.0);
+
     input_method = get_string("input_method", "WIN32");
 
     wind_mouse_enabled = get_bool("wind_mouse_enabled", false);
@@ -679,6 +697,13 @@ bool Config::saveConfig(const std::string& filename)
         << "easynorecoil = " << (easynorecoil ? "true" : "false") << "\n"
         << std::fixed << std::setprecision(1)
         << "easynorecoilstrength = " << easynorecoilstrength << "\n"
+        << std::fixed << std::setprecision(1) << "recoil_pull_down_strength = " << recoil_pull_down_strength << "\n"
+        << "recoil_pull_left_strength = " << recoil_pull_left_strength << "\n"
+        << "recoil_pull_left_delay = " << recoil_pull_left_delay << "\n"
+        << "recoil_pull_right_strength = " << recoil_pull_right_strength << "\n"
+        << "recoil_pull_right_delay = " << recoil_pull_right_delay << "\n"
+        << std::fixed << std::setprecision(2) << "recoil_sway_speed = " << recoil_sway_speed << "\n"
+        << "recoil_sway = " << recoil_sway << "\n"
         << "# WIN32, GHUB, ARDUINO, KMBOX_NET, KMBOX_A, MAKCU\n"
         << "input_method = " << input_method << "\n\n";
 

--- a/sunone_aimbot_2/config/config.cpp
+++ b/sunone_aimbot_2/config/config.cpp
@@ -52,7 +52,6 @@ bool Config::loadConfig(const std::string& filename)
     {
         std::cerr << "[Config] Config file does not exist, creating default config: " << target << std::endl;
 
-        // Capture
         capture_method = "duplication_api";
         capture_target = "monitor";
         capture_window_title = "";
@@ -68,13 +67,11 @@ bool Config::loadConfig(const std::string& filename)
         virtual_camera_width = 1920;
         virtual_camera_heigth = 1080;
 
-        // Target
         disable_headshot = false;
         body_y_offset = 0.15f;
         head_y_offset = 0.05f;
         auto_aim = false;
 
-        // Mouse
         fovX = 106;
         fovY = 74;
         minSpeedMultiplier = 0.1f;
@@ -103,36 +100,29 @@ bool Config::loadConfig(const std::string& filename)
         easynorecoilstrength = 0.0f;
         input_method = "WIN32";
 
-        // Wind mouse
         wind_mouse_enabled = false;
         wind_G = 18.0f;
         wind_W = 15.0f;
         wind_M = 10.0f;
         wind_D = 8.0f;
 
-        // Arduino
         arduino_baudrate = 115200;
         arduino_port = "COM0";
         arduino_16_bit_mouse = false;
         arduino_enable_keys = false;
 
-        // kmbox_net
         kmbox_net_ip = "10.42.42.42";
         kmbox_net_port = "1984";
         kmbox_net_uuid = "DEADC0DE";
 
-        // kmbox_a
         kmbox_a_pidvid = "";
 
-        // makcu
         makcu_baudrate = 115200;
         makcu_port = "COM0";
 
-        // Mouse shooting
         auto_shoot = false;
         bScope_multiplier = 1.0f;
 
-        // AI
 #ifdef USE_CUDA
         backend = "TRT";
 #else
@@ -155,7 +145,6 @@ bool Config::loadConfig(const std::string& filename)
 #endif
         fixed_input_size = false;
 
-        // CUDA
 #ifdef USE_CUDA
         use_cuda_graph = false;
         use_pinned_memory = false;
@@ -164,11 +153,9 @@ bool Config::loadConfig(const std::string& filename)
         capture_use_cuda = true;
 #endif
 
-        // System
         cpuCoreReserveCount = 4;
         systemMemoryReserveMB = 2048;
 
-        // Buttons
         button_targeting = splitString("RightMouseButton");
         button_shoot = splitString("LeftMouseButton");
         button_zoom = splitString("RightMouseButton");
@@ -178,12 +165,10 @@ bool Config::loadConfig(const std::string& filename)
         button_open_overlay = splitString("Home");
         enable_arrows_settings = false;
 
-        // Overlay
         overlay_opacity = 225;
         overlay_ui_scale = 1.0f;
         overlay_exclude_from_capture = true;
 
-        // Depth
         depth_inference_enabled = true;
         depth_model_path = "depth_anything_v2.engine";
         depth_fps = 100;
@@ -197,7 +182,6 @@ bool Config::loadConfig(const std::string& filename)
         depth_mask_invert = false;
         depth_debug_overlay_enabled = false;
 
-        // Game overlay
         game_overlay_enabled = false;
         game_overlay_max_fps = 0;
         game_overlay_draw_boxes = true;
@@ -227,7 +211,16 @@ bool Config::loadConfig(const std::string& filename)
         game_overlay_icon_anchor = "center";
         game_overlay_icon_class = -1;
 
-        // Aim simulation overlay
+        show_crosshair = false;
+        crosshair_x = 0.0f;
+        crosshair_y = 0.0f;
+        crosshair_scale = 1.0f;
+        crosshair_smart_color = false;
+        crosshair_hue = 0.0f;
+        crosshair_saturation = 0.0f;
+        crosshair_alpha = 1.0f;
+        current_crosshair = "";
+
         aim_sim_enabled = false;
         aim_sim_x = 24;
         aim_sim_y = 24;
@@ -248,18 +241,16 @@ bool Config::loadConfig(const std::string& filename)
         aim_sim_show_history = true;
         aim_sim_show_kalman_debug = true;
 
-        // Classes
         class_player = 0;
         class_head = 1;
 
-        // Debug
         show_window = true;
         show_fps = false;
+        show_console = true;
         screenshot_button = splitString("None");
         screenshot_delay = 500;
         verbose = false;
 
-        // Game profiles
         game_profiles.clear();
         GameProfile uni;
         uni.name = "UNIFIED";
@@ -291,19 +282,19 @@ bool Config::loadConfig(const std::string& filename)
     };
 
     auto get_bool = [&](const char* key, bool defval)
-        {
-            return ini.GetBoolValue("", key, defval);
-        };
+    {
+        return ini.GetBoolValue("", key, defval);
+    };
 
     auto get_long = [&](const char* key, long defval)
-        {
-            return (int)ini.GetLongValue("", key, defval);
-        };
+    {
+        return (int)ini.GetLongValue("", key, defval);
+    };
 
     auto get_double = [&](const char* key, double defval)
-        {
-            return ini.GetDoubleValue("", key, defval);
-        };
+    {
+        return ini.GetDoubleValue("", key, defval);
+    };
 
     game_profiles.clear();
 
@@ -354,7 +345,6 @@ bool Config::loadConfig(const std::string& filename)
     if (!game_profiles.count(active_game) && !game_profiles.empty())
         active_game = game_profiles.begin()->first;
 
-    // Capture
     capture_method = get_string("capture_method", "duplication_api");
     capture_target = get_string("capture_target", "monitor");
     capture_window_title = get_string("capture_window_title", "");
@@ -375,13 +365,11 @@ bool Config::loadConfig(const std::string& filename)
     virtual_camera_width = get_long("virtual_camera_width", 1920);
     virtual_camera_heigth = get_long("virtual_camera_heigth", 1080);
 
-    // Target
     disable_headshot = get_bool("disable_headshot", false);
     body_y_offset = (float)get_double("body_y_offset", 0.15);
     head_y_offset = (float)get_double("head_y_offset", 0.05);
     auto_aim = get_bool("auto_aim", false);
 
-    // Mouse
     fovX = get_long("fovX", 106);
     fovY = get_long("fovY", 74);
     minSpeedMultiplier = (float)get_double("minSpeedMultiplier", 0.1);
@@ -410,36 +398,29 @@ bool Config::loadConfig(const std::string& filename)
     easynorecoilstrength = (float)get_double("easynorecoilstrength", 0.0);
     input_method = get_string("input_method", "WIN32");
 
-    // Wind mouse
     wind_mouse_enabled = get_bool("wind_mouse_enabled", false);
     wind_G = (float)get_double("wind_G", 18.0f);
     wind_W = (float)get_double("wind_W", 15.0f);
     wind_M = (float)get_double("wind_M", 10.0f);
     wind_D = (float)get_double("wind_D", 8.0f);
 
-    // Arduino
     arduino_baudrate = get_long("arduino_baudrate", 115200);
     arduino_port = get_string("arduino_port", "COM0");
     arduino_16_bit_mouse = get_bool("arduino_16_bit_mouse", false);
     arduino_enable_keys = get_bool("arduino_enable_keys", false);
 
-    // kmbox_net
     kmbox_net_ip = get_string("kmbox_net_ip", "10.42.42.42");
     kmbox_net_port = get_string("kmbox_net_port", "1984");
     kmbox_net_uuid = get_string("kmbox_net_uuid", "DEADC0DE");
 
-    // kmbox_a
     kmbox_a_pidvid = get_string("kmbox_a_pidvid", "");
 
-    // makcu
     makcu_baudrate = get_long("makcu_baudrate", 115200);
     makcu_port = get_string("makcu_port", "COM0");
 
-    // Mouse shooting
     auto_shoot = get_bool("auto_shoot", false);
     bScope_multiplier = (float)get_double("bScope_multiplier", 1.2);
 
-    // AI
 #ifdef USE_CUDA
     backend = get_string("backend", "TRT");
 #else
@@ -460,7 +441,6 @@ bool Config::loadConfig(const std::string& filename)
     export_enable_fp8 = get_bool("export_enable_fp8", true);
     export_enable_fp16 = get_bool("export_enable_fp16", true);
 #endif
-    // CUDA
 #ifdef USE_CUDA
     use_cuda_graph = get_bool("use_cuda_graph", false);
     use_pinned_memory = get_bool("use_pinned_memory", true);
@@ -469,11 +449,9 @@ bool Config::loadConfig(const std::string& filename)
     capture_use_cuda = get_bool("capture_use_cuda", true);
 #endif
 
-    // System
     cpuCoreReserveCount = get_long("cpuCoreReserveCount", 4);
     systemMemoryReserveMB = get_long("systemMemoryReserveMB", 2048);
 
-    // Buttons
     button_targeting = splitString(get_string("button_targeting", "RightMouseButton"));
     button_shoot = splitString(get_string("button_shoot", "LeftMouseButton"));
     button_zoom = splitString(get_string("button_zoom", "RightMouseButton"));
@@ -483,12 +461,10 @@ bool Config::loadConfig(const std::string& filename)
     button_open_overlay = splitString(get_string("button_open_overlay", "Home"));
     enable_arrows_settings = get_bool("enable_arrows_settings", false);
 
-    // Overlay
     overlay_opacity = get_long("overlay_opacity", 225);
     overlay_ui_scale = (float)get_double("overlay_ui_scale", 1.0);
     overlay_exclude_from_capture = get_bool("overlay_exclude_from_capture", true);
 
-    // Depth
     depth_inference_enabled = get_bool("depth_inference_enabled", true);
     depth_model_path = get_string("depth_model_path", "depth_anything_v2.engine");
     depth_fps = get_long("depth_fps", 100);
@@ -543,7 +519,16 @@ bool Config::loadConfig(const std::string& filename)
     game_overlay_icon_anchor = get_string("game_overlay_icon_anchor", "center");
     game_overlay_icon_class = get_long("game_overlay_icon_class", -1);
 
-    // Aim simulation overlay
+    show_crosshair = get_bool("show_crosshair", false);
+    crosshair_x = (float)get_double("crosshair_x", 0.0);
+    crosshair_y = (float)get_double("crosshair_y", 0.0);
+    crosshair_scale = (float)get_double("crosshair_scale", 1.0);
+    crosshair_smart_color = get_bool("crosshair_smart_color", false);
+    crosshair_hue = (float)get_double("crosshair_hue", 0.0);
+    crosshair_saturation = (float)get_double("crosshair_saturation", 0.0);
+    crosshair_alpha = (float)get_double("crosshair_alpha", 1.0);
+    current_crosshair = get_string("current_crosshair", "");
+
     aim_sim_enabled = get_bool("aim_sim_enabled", false);
     aim_sim_x = get_long("aim_sim_x", 24);
     aim_sim_y = get_long("aim_sim_y", 24);
@@ -610,12 +595,13 @@ bool Config::loadConfig(const std::string& filename)
     if (aim_sim_target_stop_chance < 0.0f) aim_sim_target_stop_chance = 0.0f;
     if (aim_sim_target_stop_chance > 0.95f) aim_sim_target_stop_chance = 0.95f;
 
-    // Classes
     class_player = get_long("class_player", 0);
     class_head = get_long("class_head", 1);
 
-    // Debug window
     show_window = get_bool("show_window", true);
+    show_fps = get_bool("show_fps", false);
+    show_console = get_bool("show_console", true);
+    ::ShowWindow(::GetConsoleWindow(), show_console ? SW_SHOW : SW_HIDE);
     screenshot_button = splitString(get_string("screenshot_button", "None"));
     screenshot_delay = get_long("screenshot_delay", 500);
     verbose = get_bool("verbose", false);
@@ -641,7 +627,6 @@ bool Config::saveConfig(const std::string& filename)
     file << "# An explanation of the options can be found at:\n";
     file << "# https://github.com/SunOner/sunone_aimbot_2/blob/main/docs/config.md\n\n";
 
-    // Capture
     file << "# Capture\n"
         << "capture_method = " << capture_method << "\n"
         << "capture_target = " << capture_target << "\n"
@@ -658,7 +643,6 @@ bool Config::saveConfig(const std::string& filename)
         << "virtual_camera_width = " << virtual_camera_width << "\n"
         << "virtual_camera_heigth = " << virtual_camera_heigth << "\n\n";
 
-    // Target
     file << "# Target\n"
         << "disable_headshot = " << (disable_headshot ? "true" : "false") << "\n"
         << std::fixed << std::setprecision(2)
@@ -666,13 +650,11 @@ bool Config::saveConfig(const std::string& filename)
         << "head_y_offset = " << head_y_offset << "\n"
         << "auto_aim = " << (auto_aim ? "true" : "false") << "\n\n";
 
-    // Mouse
     file << "# Mouse move\n"
         << "fovX = " << fovX << "\n"
         << "fovY = " << fovY << "\n"
         << "minSpeedMultiplier = " << minSpeedMultiplier << "\n"
         << "maxSpeedMultiplier = " << maxSpeedMultiplier << "\n"
-
         << std::fixed << std::setprecision(2)
         << "predictionInterval = " << predictionInterval << "\n"
         << "prediction_futurePositions = " << prediction_futurePositions << "\n"
@@ -689,21 +671,17 @@ bool Config::saveConfig(const std::string& filename)
         << std::fixed << std::setprecision(2)
         << "kalman_additional_prediction_ms = " << kalman_additional_prediction_ms << "\n"
         << "kalman_reset_timeout_sec = " << kalman_reset_timeout_sec << "\n"
-
         << "snapRadius = " << snapRadius << "\n"
         << "nearRadius = " << nearRadius << "\n"
         << "speedCurveExponent = " << speedCurveExponent << "\n"
         << std::fixed << std::setprecision(2)
         << "snapBoostFactor = " << snapBoostFactor << "\n"
-
         << "easynorecoil = " << (easynorecoil ? "true" : "false") << "\n"
         << std::fixed << std::setprecision(1)
         << "easynorecoilstrength = " << easynorecoilstrength << "\n"
-
         << "# WIN32, GHUB, ARDUINO, KMBOX_NET, KMBOX_A, MAKCU\n"
         << "input_method = " << input_method << "\n\n";
 
-    // Wind mouse
     file << "# Wind mouse\n"
         << "wind_mouse_enabled = " << (wind_mouse_enabled ? "true" : "false") << "\n"
         << "wind_G = " << wind_G << "\n"
@@ -711,14 +689,12 @@ bool Config::saveConfig(const std::string& filename)
         << "wind_M = " << wind_M << "\n"
         << "wind_D = " << wind_D << "\n\n";
 
-    // Arduino
     file << "# Arduino\n"
         << "arduino_baudrate = " << arduino_baudrate << "\n"
         << "arduino_port = " << arduino_port << "\n"
         << "arduino_16_bit_mouse = " << (arduino_16_bit_mouse ? "true" : "false") << "\n"
         << "arduino_enable_keys = " << (arduino_enable_keys ? "true" : "false") << "\n\n";
 
-    // kmbox_net
     file << "# Kmbox_net\n"
         << "kmbox_net_ip = " << kmbox_net_ip << "\n"
         << "kmbox_net_port = " << kmbox_net_port << "\n"
@@ -727,18 +703,15 @@ bool Config::saveConfig(const std::string& filename)
     file << "# Kmbox_a\n"
         << "kmbox_a_pidvid = " << kmbox_a_pidvid << "\n\n";
 
-    // makcu
     file << "# Makcu\n"
         << "makcu_baudrate = " << makcu_baudrate << "\n"
-		<< "makcu_port = " << makcu_port << "\n\n";
+        << "makcu_port = " << makcu_port << "\n\n";
 
-    // Mouse shooting
     file << "# Mouse shooting\n"
         << "auto_shoot = " << (auto_shoot ? "true" : "false") << "\n"
         << std::fixed << std::setprecision(1)
         << "bScope_multiplier = " << bScope_multiplier << "\n\n";
 
-    // AI
     file << "# AI\n"
         << "backend = " << backend << "\n"
         << "dml_device_id = " << dml_device_id << "\n"
@@ -754,7 +727,6 @@ bool Config::saveConfig(const std::string& filename)
 #endif
         ;
 
-    // CUDA
 #ifdef USE_CUDA
     file << "\n# CUDA\n"
         << "use_cuda_graph = " << (use_cuda_graph ? "true" : "false") << "\n"
@@ -764,12 +736,10 @@ bool Config::saveConfig(const std::string& filename)
         << "capture_use_cuda = " << (capture_use_cuda ? "true" : "false") << "\n\n";
 #endif
 
-	// System
     file << "# System\n"
         << "cpuCoreReserveCount = " << cpuCoreReserveCount << "\n"
         << "systemMemoryReserveMB = " << systemMemoryReserveMB << "\n\n";
 
-    // Buttons
     file << "# Buttons\n"
         << "button_targeting = " << joinStrings(button_targeting) << "\n"
         << "button_shoot = " << joinStrings(button_shoot) << "\n"
@@ -780,7 +750,6 @@ bool Config::saveConfig(const std::string& filename)
         << "button_open_overlay = " << joinStrings(button_open_overlay) << "\n"
         << "enable_arrows_settings = " << (enable_arrows_settings ? "true" : "false") << "\n\n";
 
-    // Overlay
     file << "# Overlay\n"
         << "overlay_opacity = " << overlay_opacity << "\n"
         << std::fixed << std::setprecision(2)
@@ -834,6 +803,18 @@ bool Config::saveConfig(const std::string& filename)
         << "game_overlay_icon_anchor = " << game_overlay_icon_anchor << "\n"
         << "game_overlay_icon_class = " << game_overlay_icon_class << "\n\n";
 
+    file << "# Crosshair\n"
+        << "show_crosshair = " << (show_crosshair ? "true" : "false") << "\n"
+        << std::fixed << std::setprecision(3)
+        << "crosshair_x = " << crosshair_x << "\n"
+        << "crosshair_y = " << crosshair_y << "\n"
+        << "crosshair_scale = " << crosshair_scale << "\n"
+        << "crosshair_smart_color = " << (crosshair_smart_color ? "true" : "false") << "\n"
+        << "crosshair_hue = " << crosshair_hue << "\n"
+        << "crosshair_saturation = " << crosshair_saturation << "\n"
+        << "crosshair_alpha = " << crosshair_alpha << "\n"
+        << "current_crosshair = " << current_crosshair << "\n\n";
+
     file << "# Aim Simulation Overlay\n"
         << "aim_sim_enabled = " << (aim_sim_enabled ? "true" : "false") << "\n"
         << "aim_sim_x = " << aim_sim_x << "\n"
@@ -857,20 +838,18 @@ bool Config::saveConfig(const std::string& filename)
         << "aim_sim_show_history = " << (aim_sim_show_history ? "true" : "false") << "\n"
         << "aim_sim_show_kalman_debug = " << (aim_sim_show_kalman_debug ? "true" : "false") << "\n\n";
 
-    // Classes
     file << "# Custom Classes\n"
         << "class_player = " << class_player << "\n"
         << "class_head = " << class_head << "\n\n";
 
-    // Debug
     file << "# Debug\n"
         << "show_window = " << (show_window ? "true" : "false") << "\n"
         << "show_fps = " << (show_fps ? "true" : "false") << "\n"
+        << "show_console = " << (show_console ? "true" : "false") << "\n"
         << "screenshot_button = " << joinStrings(screenshot_button) << "\n"
         << "screenshot_delay = " << screenshot_delay << "\n"
         << "verbose = " << (verbose ? "true" : "false") << "\n\n";
 
-    // Active game
     file << "# Active game profile\n";
     file << "active_game = " << active_game << "\n\n";
     file << "[Games]\n";

--- a/sunone_aimbot_2/config/config.h
+++ b/sunone_aimbot_2/config/config.h
@@ -27,10 +27,20 @@ public:
     bool disable_headshot;
     float body_y_offset;
     float head_y_offset;
+    float body_x_offset;
     bool auto_aim;
+    bool ignore_third_person;
+    bool shooting_range_targets;
 
     int fovX;
     int fovY;
+    bool enable_dynamic_fov;
+    int fovX_hipfire;
+    int fovY_hipfire;
+    int fovX_ads;
+    int fovY_ads;
+    float hipfire_smooth;
+    
     float minSpeedMultiplier;
     float maxSpeedMultiplier;
 

--- a/sunone_aimbot_2/config/config.h
+++ b/sunone_aimbot_2/config/config.h
@@ -9,8 +9,7 @@
 class Config
 {
 public:
-    // Capture
-    std::string capture_method; // "duplication_api", "winrt", "virtual_camera", "udp_capture"
+    std::string capture_method; 
     std::string capture_target;
     std::string capture_window_title;
     std::string udp_ip;
@@ -25,13 +24,11 @@ public:
     int virtual_camera_width;
     int virtual_camera_heigth;
 
-    // Target
     bool disable_headshot;
     float body_y_offset;
     float head_y_offset;
     bool auto_aim;
 
-    // Mouse
     int fovX;
     int fovY;
     float minSpeedMultiplier;
@@ -58,38 +55,31 @@ public:
 
     bool easynorecoil;
     float easynorecoilstrength;
-    std::string input_method; // "WIN32", "GHUB", "ARDUINO", "KMBOX_NET", "KMBOX_A", "MAKCU"
+    std::string input_method; 
 
-    // Wind mouse
     bool wind_mouse_enabled;
     float wind_G;
     float wind_W;
     float wind_M;
     float wind_D;
 
-    // Arduino
     int arduino_baudrate;
     std::string arduino_port;
     bool arduino_16_bit_mouse;
     bool arduino_enable_keys;
 
-    // kmbox_net
     std::string kmbox_net_ip;
     std::string kmbox_net_port;
     std::string kmbox_net_uuid;
 
-    // kmbox_a
-    std::string kmbox_a_pidvid; // PIDVID in one field, format: PPPPVVVV
+    std::string kmbox_a_pidvid; 
 
-    // makcu
     int makcu_baudrate;
     std::string makcu_port;
 
-    // Mouse shooting
     bool auto_shoot;
     float bScope_multiplier;
 
-    // AI
     std::string backend;
     int dml_device_id;
     std::string ai_model;
@@ -102,7 +92,6 @@ public:
 #endif
     bool fixed_input_size;
 
-    // CUDA
 #ifdef USE_CUDA
     bool use_cuda_graph;
     bool use_pinned_memory;
@@ -111,11 +100,9 @@ public:
     bool capture_use_cuda;
 #endif
 
-    // System
     int cpuCoreReserveCount;
     int systemMemoryReserveMB;
 
-    // Buttons
     std::vector<std::string> button_targeting;
     std::vector<std::string> button_shoot;
     std::vector<std::string> button_zoom;
@@ -125,12 +112,10 @@ public:
     std::vector<std::string> button_open_overlay;
     bool enable_arrows_settings;
 
-    // Overlay
     int overlay_opacity;
     float overlay_ui_scale;
     bool overlay_exclude_from_capture;
 
-    // Depth
     bool depth_inference_enabled;
     std::string depth_model_path;
     int depth_fps;
@@ -144,7 +129,6 @@ public:
     bool depth_mask_invert;
     bool depth_debug_overlay_enabled;
 
-    // Game Overlay
     bool game_overlay_enabled;
     int game_overlay_max_fps;
     bool game_overlay_draw_boxes;
@@ -171,10 +155,19 @@ public:
     int game_overlay_icon_height;
     float game_overlay_icon_offset_x;
     float game_overlay_icon_offset_y;
-    std::string game_overlay_icon_anchor; // "center", "top", "bottom", "head"
-    int game_overlay_icon_class; // -1 = all
+    std::string game_overlay_icon_anchor; 
+    int game_overlay_icon_class; 
 
-    // Aim Simulation Overlay
+    bool show_crosshair;
+    float crosshair_x;
+    float crosshair_y;
+    float crosshair_scale;
+    bool crosshair_smart_color;
+    float crosshair_hue;
+    float crosshair_saturation;
+    float crosshair_alpha;
+    std::string current_crosshair;
+
     bool aim_sim_enabled;
     int aim_sim_x;
     int aim_sim_y;
@@ -208,13 +201,12 @@ public:
         clamp255(game_overlay_frame_b);
     }
 
-    // Classes
     int class_player;
     int class_head;
 
-    // Debug
     bool show_window;
     bool show_fps;
+    bool show_console;
     std::vector<std::string> screenshot_button;
     int screenshot_delay;
     bool verbose;

--- a/sunone_aimbot_2/config/config.h
+++ b/sunone_aimbot_2/config/config.h
@@ -55,6 +55,15 @@ public:
 
     bool easynorecoil;
     float easynorecoilstrength;
+    
+    float recoil_pull_down_strength;
+    float recoil_pull_left_strength;
+    float recoil_pull_left_delay;
+    float recoil_pull_right_strength;
+    float recoil_pull_right_delay;
+    float recoil_sway_speed;
+    float recoil_sway;
+
     std::string input_method; 
 
     bool wind_mouse_enabled;

--- a/sunone_aimbot_2/overlay/Game_overlay.cpp
+++ b/sunone_aimbot_2/overlay/Game_overlay.cpp
@@ -1,4 +1,4 @@
-﻿#define WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <dwmapi.h>
 #include <d3d11.h>
@@ -46,7 +46,7 @@ static void SetPerMonitorV2DpiAwareness()
     if (!user32) return;
     using Fn = BOOL(WINAPI*)(HANDLE);
     if (auto p = reinterpret_cast<Fn>(GetProcAddress(user32, "SetProcessDpiAwarenessContext")))
-        p(reinterpret_cast<HANDLE>(-4)); // PER_MONITOR_AWARE_V2
+        p(reinterpret_cast<HANDLE>(-4)); 
 }
 
 static D2D1_COLOR_F ToD2DColor(OverlayColor argb)
@@ -449,7 +449,6 @@ bool Game_overlay::Impl::CreateWindowAndDevices()
     }
 
     ShowWindow(hwnd, SW_SHOWNA);
-    ApplyDisplayAffinity();
     SetWindowPos(hwnd, HWND_TOPMOST, winX, winY, winW, winH,
         SWP_NOACTIVATE | SWP_SHOWWINDOW);
 
@@ -472,7 +471,6 @@ bool Game_overlay::Impl::CreateWindowAndDevices()
         return false;
     }
 
-    // DXGI factory
     ComPtr<IDXGIDevice> dxgiDev; d3d.As(&dxgiDev);
     ComPtr<IDXGIAdapter> adapter; dxgiDev->GetAdapter(&adapter);
     ComPtr<IDXGIFactory2> factory2;
@@ -657,21 +655,40 @@ void Game_overlay::Impl::ApplyDisplayAffinity()
         return;
 
     const bool wantedExclude = excludeFromCapture.load();
-    appliedExcludeFromCapture = wantedExclude;
     const DWORD affinity = wantedExclude ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
+    
     if (SetWindowDisplayAffinity(hwnd, affinity))
+    {
+        appliedExcludeFromCapture = wantedExclude; 
         return;
+    }
+
+    const DWORD err = GetLastError();
+    
+    if (err == 8) 
+    {
+        return; 
+    }
 
     if (wantedExclude)
     {
-        const DWORD err = GetLastError();
         std::cerr << "[GameOverlay] SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE) failed, err=" << err
                   << ". Trying WDA_MONITOR fallback." << std::endl;
-        if (!SetWindowDisplayAffinity(hwnd, WDA_MONITOR))
+                  
+        if (SetWindowDisplayAffinity(hwnd, WDA_MONITOR))
+        {
+            appliedExcludeFromCapture = wantedExclude;
+        }
+        else
         {
             std::cerr << "[GameOverlay] SetWindowDisplayAffinity(WDA_MONITOR) failed, err="
                       << GetLastError() << std::endl;
+            appliedExcludeFromCapture = wantedExclude;
         }
+    }
+    else
+    {
+        appliedExcludeFromCapture = wantedExclude;
     }
 }
 
@@ -679,6 +696,7 @@ void Game_overlay::Impl::RenderLoop()
 {
     running = true;
     auto last = std::chrono::high_resolution_clock::now();
+    
     appliedExcludeFromCapture = !excludeFromCapture.load();
 
     MSG msg{};
@@ -707,6 +725,7 @@ void Game_overlay::Impl::RenderLoop()
 
         if (appliedExcludeFromCapture != excludeFromCapture.load())
             ApplyDisplayAffinity();
+            
         RenderOne();
     }
 }

--- a/sunone_aimbot_2/overlay/crosshair_feature.cpp
+++ b/sunone_aimbot_2/overlay/crosshair_feature.cpp
@@ -1,0 +1,325 @@
+#include <imgui.h>
+#include <vector>
+#include <string>
+#include <filesystem>
+#include <d3d11.h>
+#include <mutex>
+#include <opencv2/opencv.hpp> 
+#include "config.h"
+#include "overlay/config_dirty.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "include/stb_image.h" 
+
+extern Config config;
+extern ID3D11Device* g_pd3dDevice; 
+
+cv::Mat latestFrameCpu;
+extern std::mutex frameMutex;
+
+struct CrosshairIcon {
+    std::string filename;
+    ID3D11ShaderResourceView* texture;
+    int width, height;
+};
+
+static std::vector<CrosshairIcon> crosshair_icons;
+static bool crosshairs_loaded = false;
+static ID3D11ShaderResourceView* active_crosshair_tex = nullptr;
+static ImVec4 currentSmoothColor = ImVec4(0, 1, 1, 1);
+
+#define CONFIG_CX config.crosshair_x
+#define CONFIG_CY config.crosshair_y
+
+void RGBtoHSV(float r, float g, float b, float& h, float& s, float& v) {
+    ImGui::ColorConvertRGBtoHSV(r, g, b, h, s, v);
+}
+
+void HSVtoRGB(float h, float s, float v, float& r, float& g, float& b) {
+    ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b);
+}
+
+ImVec4 GetSmartColor() {
+    ImVec4 targetColor = currentSmoothColor;
+
+    if (!latestFrameCpu.empty() && frameMutex.try_lock()) {
+        int cx = latestFrameCpu.cols / 2;
+        int cy = latestFrameCpu.rows / 2;
+        int radius = 30 + (int)(config.crosshair_scale * 20.0f); 
+        
+        if (cx > radius && cx < latestFrameCpu.cols - radius && cy > radius && cy < latestFrameCpu.rows - radius) {
+            float rTot = 0, gTot = 0, bTot = 0;
+            int count = 0;
+            int diag = (int)(radius * 0.707f);
+            int offsets[8][2] = {
+                {radius, 0}, {-radius, 0}, {0, radius}, {0, -radius},
+                {diag, diag}, {-diag, -diag}, {diag, -diag}, {-diag, diag}
+            };
+
+            for (int i = 0; i < 8; i++) {
+                cv::Vec4b p = latestFrameCpu.at<cv::Vec4b>(cy + offsets[i][1], cx + offsets[i][0]);
+                bTot += p[0]; gTot += p[1]; rTot += p[2];
+                count++;
+            }
+
+            float avgR = (rTot / count) / 255.0f;
+            float avgG = (gTot / count) / 255.0f;
+            float avgB = (bTot / count) / 255.0f;
+
+            float h, s, v;
+            RGBtoHSV(avgR, avgG, avgB, h, s, v);
+
+            if (s < 0.2f) { 
+                if (v > 0.6f) {
+                    targetColor = ImVec4(0.05f, 0.05f, 0.05f, 1.0f); 
+                } else {
+                    targetColor = ImVec4(0.0f, 1.0f, 1.0f, 1.0f);
+                }
+            } else {
+                float targetR = 1.0f - avgR;
+                float targetG = 1.0f - avgG;
+                float targetB = 1.0f - avgB;
+                float th, ts, tv;
+
+                RGBtoHSV(targetR, targetG, targetB, th, ts, tv);
+                HSVtoRGB(th, 1.0f, 1.0f, targetColor.x, targetColor.y, targetColor.z);
+                targetColor.w = 1.0f;
+            }
+        }
+        frameMutex.unlock();
+    }
+
+    float dt = ImGui::GetIO().DeltaTime; 
+    float step = dt * 15.0f; 
+    if (step > 1.0f) step = 1.0f; 
+
+    currentSmoothColor.x += (targetColor.x - currentSmoothColor.x) * step;
+    currentSmoothColor.y += (targetColor.y - currentSmoothColor.y) * step;
+    currentSmoothColor.z += (targetColor.z - currentSmoothColor.z) * step;
+    currentSmoothColor.w = 1.0f; 
+
+    return currentSmoothColor;
+}
+
+bool LoadTextureFromFile(const char* filename, ID3D11ShaderResourceView** out_srv, int* out_width, int* out_height) {
+    int image_width = 0; 
+    int image_height = 0;
+    unsigned char* image_data = stbi_load(filename, &image_width, &image_height, NULL, 4);
+    if (image_data == NULL) return false;
+    
+    D3D11_TEXTURE2D_DESC desc; 
+    ZeroMemory(&desc, sizeof(desc));
+    desc.Width = image_width; 
+    desc.Height = image_height; 
+    desc.MipLevels = 1; 
+    desc.ArraySize = 1;
+    desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM; 
+    desc.SampleDesc.Count = 1; 
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_SHADER_RESOURCE; 
+    desc.CPUAccessFlags = 0;
+    
+    ID3D11Texture2D* pTexture = NULL;
+    D3D11_SUBRESOURCE_DATA subResource; 
+    subResource.pSysMem = image_data; 
+    subResource.SysMemPitch = desc.Width * 4; 
+    subResource.SysMemSlicePitch = 0;
+    
+    g_pd3dDevice->CreateTexture2D(&desc, &subResource, &pTexture);
+    
+    D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc; 
+    ZeroMemory(&srvDesc, sizeof(srvDesc));
+    srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM; 
+    srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D; 
+    srvDesc.Texture2D.MipLevels = desc.MipLevels;
+    
+    g_pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, out_srv);
+    pTexture->Release();
+    
+    *out_width = image_width; 
+    *out_height = image_height;
+    stbi_image_free(image_data);
+    return true;
+}
+
+void RefreshCrosshairs() {
+    for (auto& icon : crosshair_icons) {
+        if (icon.texture) icon.texture->Release();
+    }
+    crosshair_icons.clear();
+    
+    if (!std::filesystem::exists("crosshairs")) {
+        std::filesystem::create_directory("crosshairs");
+    }
+    
+    for (const auto& entry : std::filesystem::directory_iterator("crosshairs")) {
+        if (!entry.is_regular_file()) continue;
+        std::string filename = entry.path().filename().string();
+        ID3D11ShaderResourceView* tex = nullptr; 
+        int w, h;
+        if (LoadTextureFromFile(entry.path().string().c_str(), &tex, &w, &h)) {
+            crosshair_icons.push_back({ filename, tex, w, h });
+            if (filename == config.current_crosshair) active_crosshair_tex = tex;
+        }
+    }
+    
+    if (!active_crosshair_tex && !crosshair_icons.empty()) {
+        active_crosshair_tex = crosshair_icons[0].texture;
+        config.current_crosshair = crosshair_icons[0].filename;
+    }
+    crosshairs_loaded = true;
+}
+
+void draw_crosshair_settings() {
+    if (!crosshairs_loaded) RefreshCrosshairs();
+
+    ImGui::TextColored(ImVec4(1.0f, 0.2f, 0.2f, 1.0f), "CROSSHAIR CONFIGURATION");
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    if (ImGui::Checkbox("Enable Crosshair Overlay", &config.show_crosshair))
+        OverlayConfig_MarkDirty();
+    
+    ImGui::TextDisabled("(Ctrl+Click sliders to type)");
+    
+    ImGui::SliderFloat("X Position", &CONFIG_CX, -0.5f, 0.5f, "%.3f");
+    if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+    
+    ImGui::SliderFloat("Y Position", &CONFIG_CY, -0.5f, 0.5f, "%.3f");
+    if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+    
+    ImGui::SliderFloat("Size Scale", &config.crosshair_scale, 0.1f, 5.0f, "%.1f");
+    if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    if (ImGui::Checkbox("Smart Contrast (Auto-Color)", &config.crosshair_smart_color))
+        OverlayConfig_MarkDirty();
+
+    if (!config.crosshair_smart_color) {
+        ImGui::SliderFloat("Hue", &config.crosshair_hue, 0.0f, 1.0f, "");
+        if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+        
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+        float w = ImGui::GetContentRegionAvail().x;
+        
+        for(int i = 0; i < 64; i++) {
+            float h = i / 64.0f;
+            ImColor c; 
+            ImGui::ColorConvertHSVtoRGB(h, 1.0f, 1.0f, c.Value.x, c.Value.y, c.Value.z);
+            dl->AddRectFilled(ImVec2(p.x + (w * (i / 64.0f)), p.y - 5), ImVec2(p.x + (w * ((i + 1) / 64.0f)), p.y), c);
+        }
+
+        ImGui::SliderFloat("Saturation", &config.crosshair_saturation, 0.0f, 1.0f, "%.2f");
+        if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+    } else {
+        ImGui::SameLine();
+        ImGui::ColorButton("##SmartCol", currentSmoothColor, ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoPicker, ImVec2(20, 20));
+        ImGui::SameLine();
+        ImGui::TextDisabled("Auto-Fading");
+    }
+
+    ImGui::SliderFloat("Opacity", &config.crosshair_alpha, 0.0f, 1.0f, "%.2f");
+    if (ImGui::IsItemDeactivatedAfterEdit()) OverlayConfig_MarkDirty();
+
+    ImGui::Spacing();
+    if (ImGui::Button("Reset Defaults")) {
+        CONFIG_CX = 0.0f; 
+        CONFIG_CY = 0.0f;
+        config.crosshair_scale = 1.0f;
+        config.crosshair_hue = 0.0f;        
+        config.crosshair_saturation = 0.0f; 
+        config.crosshair_alpha = 1.0f;
+        config.crosshair_smart_color = false;
+        OverlayConfig_MarkDirty();
+    }
+
+    ImGui::Dummy(ImVec2(0, 10));
+    ImGui::Separator();
+    
+    if (ImGui::Button("Refresh List")) {
+        RefreshCrosshairs();
+    }
+
+    ImGui::Spacing();
+
+    ImGui::BeginChild("Grid", ImVec2(0, 300), true, ImGuiWindowFlags_AlwaysVerticalScrollbar);
+    float window_visible_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+    ImGuiStyle& style = ImGui::GetStyle();
+    int buttons_count = (int)crosshair_icons.size();
+    
+    ImVec4 tintColor;
+    ImGui::ColorConvertHSVtoRGB(config.crosshair_hue, config.crosshair_saturation, 1.0f, tintColor.x, tintColor.y, tintColor.z);
+    tintColor.w = 1.0f;
+
+    for (int n = 0; n < buttons_count; n++) {
+        ImGui::PushID(n);
+        
+        bool is_selected = (config.current_crosshair == crosshair_icons[n].filename);
+        
+        if (is_selected) {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.2f, 0.2f, 0.4f)); 
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 0.2f, 0.2f, 0.6f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 0.2f, 0.2f, 0.8f));
+        } else {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.1f, 0.1f, 0.1f, 0.5f)); 
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.3f, 0.3f, 0.3f, 0.5f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.4f, 0.4f, 0.4f, 0.5f));
+        }
+
+        if (ImGui::ImageButton("##btn", crosshair_icons[n].texture, ImVec2(64, 64), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0), tintColor)) {
+            config.current_crosshair = crosshair_icons[n].filename;
+            active_crosshair_tex = crosshair_icons[n].texture;
+            OverlayConfig_MarkDirty();
+        }
+
+        ImGui::PopStyleColor(3);
+
+        float last_button_x2 = ImGui::GetItemRectMax().x;
+        float next_button_x2 = last_button_x2 + style.ItemSpacing.x + 64.0f;
+        if (n + 1 < buttons_count && next_button_x2 < window_visible_x2) {
+            ImGui::SameLine();
+        }
+
+        ImGui::PopID();
+    }
+    ImGui::EndChild();
+}
+
+void RenderActiveCrosshair(int screenWidth, int screenHeight) {
+    if (!crosshairs_loaded) RefreshCrosshairs();
+    if (!config.show_crosshair || !active_crosshair_tex) return;
+
+    ImDrawList* dl = ImGui::GetBackgroundDrawList();
+    
+    float baseW = 64.0f; 
+    float baseH = 64.0f;
+    
+    float screenCenterX = screenWidth / 2.0f;
+    float screenCenterY = screenHeight / 2.0f;
+
+    float finalX = screenCenterX + (screenWidth * CONFIG_CX);
+    float finalY = screenCenterY - (screenHeight * CONFIG_CY);
+
+    float finalW = baseW * config.crosshair_scale;
+    float finalH = baseH * config.crosshair_scale;
+
+    ImVec4 mainColor;
+    if (config.crosshair_smart_color) {
+        mainColor = GetSmartColor();
+    } else {
+        ImGui::ColorConvertHSVtoRGB(config.crosshair_hue, config.crosshair_saturation, 1.0f, mainColor.x, mainColor.y, mainColor.z);
+        mainColor.w = 1.0f;
+    }
+    
+    mainColor.w *= config.crosshair_alpha;
+
+    dl->AddImage(active_crosshair_tex, 
+        ImVec2(finalX - (finalW / 2), finalY - (finalH / 2)), 
+        ImVec2(finalX + (finalW / 2), finalY + (finalH / 2)),
+        ImVec2(0, 0), ImVec2(1, 1), 
+        ImColor(mainColor));
+}

--- a/sunone_aimbot_2/overlay/draw_debug.cpp
+++ b/sunone_aimbot_2/overlay/draw_debug.cpp
@@ -6,6 +6,7 @@
 #include <d3d11.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "imgui/imgui.h"
 #include "sunone_aimbot_2.h"
@@ -347,6 +348,12 @@ void draw_debug()
 
         ImGui::InputInt("Screenshot delay", &config.screenshot_delay, 50, 500);
         ImGui::Checkbox("Verbose console output", &config.verbose);
+
+        if (ImGui::Checkbox("Show Console Window", &config.show_console))
+        {
+            ::ShowWindow(::GetConsoleWindow(), config.show_console ? SW_SHOW : SW_HIDE);
+            OverlayConfig_MarkDirty();
+        }
 
         if (ImGui::Button("Print OpenCV build information##button_cv2_build_info"))
         {

--- a/sunone_aimbot_2/overlay/draw_mouse.cpp
+++ b/sunone_aimbot_2/overlay/draw_mouse.cpp
@@ -2,6 +2,7 @@
 #define _WINSOCKAPI_
 #include <winsock2.h>
 #include <Windows.h>
+#include <atomic>
 
 #include <shellapi.h>
 
@@ -14,10 +15,23 @@
 #include "include/other_tools.h"
 #include "kmbox_net/picture.h"
 
+extern std::atomic<bool> zooming;
+
+static float animated_fov_x = 0.0f;
+static float animated_fov_y = 0.0f;
+
+float Lerp(float a, float b, float t) {
+    return a + (b - a) * t;
+}
+
 std::string ghub_version = get_ghub_version();
 
-int prev_fovX = config.fovX;
-int prev_fovY = config.fovY;
+bool  prev_enable_dynamic_fov = config.enable_dynamic_fov;
+int   prev_fovX_hipfire = config.fovX_hipfire;
+int   prev_fovY_hipfire = config.fovY_hipfire;
+int   prev_fovX_ads = config.fovX_ads;
+int   prev_fovY_ads = config.fovY_ads;
+float prev_hipfire_smooth = config.hipfire_smooth;
 float prev_minSpeedMultiplier = config.minSpeedMultiplier;
 float prev_maxSpeedMultiplier = config.maxSpeedMultiplier;
 float prev_predictionInterval = config.predictionInterval;
@@ -47,10 +61,57 @@ float prev_bScope_multiplier = config.bScope_multiplier;
 
 void draw_mouse()
 {
-    if (OverlayUI::BeginSection("FOV", "mouse_section_fov"))
+    if (OverlayUI::BeginSection("FOV & ZOOM", "mouse_section_fov"))
     {
-        ImGui::SliderInt("FOV X", &config.fovX, 10, 120);
-        ImGui::SliderInt("FOV Y", &config.fovY, 10, 120);
+        if (ImGui::Checkbox("Enable Dynamic FOV (Zoom Scaling)", &config.enable_dynamic_fov)) {
+            OverlayConfig_MarkDirty();
+        }
+
+        if (config.enable_dynamic_fov)
+        {
+            float targetX = zooming.load() ? (float)config.fovX_ads : (float)config.fovX_hipfire;
+            
+            float dt = ImGui::GetIO().DeltaTime;
+            animated_fov_x = Lerp(animated_fov_x, targetX, dt * 10.0f);
+            
+            if (animated_fov_x == 0.0f) animated_fov_x = targetX;
+
+            ImGui::TextColored(ImVec4(1, 0, 0, 1), "Live Effective FOV:"); 
+            ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(1.0f, 0.0f, 0.0f, 1.0f)); 
+            ImGui::ProgressBar((animated_fov_x - 10.0f) / 490.0f, ImVec2(-1, 0), "Current Width");
+            ImGui::PopStyleColor();
+        }
+        else
+        {
+            ImGui::TextDisabled("Dynamic FOV Disabled. Using ADS settings as default.");
+        }
+
+        ImGui::Dummy(ImVec2(0, 5));
+
+        ImGui::Columns(2, "fov_cols", false);
+        
+        if (!config.enable_dynamic_fov) {
+            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+            ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.5f);
+        }
+
+        ImGui::Text("Hipfire (Dynamic Only)");
+        if (ImGui::SliderInt("Width X##Hip", &config.fovX_hipfire, 10, 500)) OverlayConfig_MarkDirty();
+        if (ImGui::SliderInt("Height Y##Hip", &config.fovY_hipfire, 10, 500)) OverlayConfig_MarkDirty();
+        if (ImGui::SliderFloat("Hipfire Smooth##Hip", &config.hipfire_smooth, 0.1f, 2.0f, "%.2f")) OverlayConfig_MarkDirty();
+        
+        if (!config.enable_dynamic_fov) {
+            ImGui::PopStyleVar();
+            ImGui::PopItemFlag();
+        }
+
+        ImGui::NextColumn();
+
+        ImGui::Text("ADS / Default");
+        if (ImGui::SliderInt("Width X##Ads", &config.fovX_ads, 10, 500)) OverlayConfig_MarkDirty();
+        if (ImGui::SliderInt("Height Y##Ads", &config.fovY_ads, 10, 500)) OverlayConfig_MarkDirty();
+
+        ImGui::Columns(1);
         OverlayUI::EndSection();
     }
 
@@ -191,12 +252,24 @@ void draw_mouse()
         {
             config.active_game = profile_names[selected_index];
             OverlayConfig_MarkDirty();
+            
+            int current_fovX = config.enable_dynamic_fov ? (zooming.load() ? config.fovX_ads : config.fovX_hipfire) : config.fovX_ads;
+            int current_fovY = config.enable_dynamic_fov ? (zooming.load() ? config.fovY_ads : config.fovY_hipfire) : config.fovY_ads;
+            
+            float pass_minSpeed = config.minSpeedMultiplier;
+            float pass_maxSpeed = config.maxSpeedMultiplier;
+            if (config.enable_dynamic_fov && !zooming.load())
+            {
+                pass_minSpeed *= config.hipfire_smooth;
+                pass_maxSpeed *= config.hipfire_smooth;
+            }
+
             globalMouseThread->updateConfig(
                 config.detection_resolution,
-                config.fovX,
-                config.fovY,
-                config.minSpeedMultiplier,
-                config.maxSpeedMultiplier,
+                current_fovX,
+                current_fovY,
+                pass_minSpeed,
+                pass_maxSpeed,
                 config.predictionInterval,
                 config.auto_shoot,
                 config.bScope_multiplier
@@ -298,37 +371,28 @@ void draw_mouse()
         OverlayUI::EndSection();
     }
 
-    if (OverlayUI::BeginSection("Recoil Control", "mouse_section_recoil"))
+    if (OverlayUI::BeginSection("Easy No Recoil", "mouse_section_easy_no_recoil"))
     {
-        if (ImGui::Checkbox("Easy No Recoil", &config.easynorecoil)) OverlayConfig_MarkDirty();
-        if (!config.easynorecoil) ImGui::BeginDisabled();
+        ImGui::Checkbox("Easy No Recoil", &config.easynorecoil);
+        if (!config.easynorecoil)
+        {
+            ImGui::BeginDisabled();
+        }
 
-        ImGui::Dummy(ImVec2(0.0f, 5.0f));
-        ImGui::Text("Vertical Compensation:");
-        if (ImGui::SliderFloat("Pull Down Strength", &config.recoil_pull_down_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
+        ImGui::SliderFloat("No Recoil Strength", &config.easynorecoilstrength, 0.1f, 500.0f, "%.1f");
+        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Left/Right Arrow keys: Adjust recoil strength by 10");
 
-        ImGui::Separator();
-        ImGui::PushID("recoil_left");
-        ImGui::Text("Left Compensation:");
-        if (ImGui::SliderFloat("Delay (ms)", &config.recoil_pull_left_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
-        if (ImGui::SliderFloat("Pull Left Strength", &config.recoil_pull_left_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
-        ImGui::PopID();
+        if (config.easynorecoilstrength >= 100.0f)
+        {
+            ImGui::TextColored(ImVec4(255, 255, 0, 255), "WARNING: High recoil strength may be detected.");
+        }
 
-        ImGui::Separator();
-        ImGui::PushID("recoil_right");
-        ImGui::Text("Right Compensation:");
-        if (ImGui::SliderFloat("Delay (ms)", &config.recoil_pull_right_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
-        if (ImGui::SliderFloat("Pull Right Strength", &config.recoil_pull_right_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
-        ImGui::PopID();
+        if (!config.easynorecoil)
+        {
+            ImGui::EndDisabled();
+            ImGui::TextDisabled("Enable Easy No Recoil to edit settings.");
+        }
 
-        ImGui::Separator();
-        ImGui::PushID("recoil_sway");
-        ImGui::Text("Humanization (Sway):");
-        if (ImGui::SliderFloat("Sway Speed", &config.recoil_sway_speed, 0.0f, 20.0f, "%.1f")) OverlayConfig_MarkDirty();
-        if (ImGui::SliderFloat("Sway Amount", &config.recoil_sway, 0.0f, 20.0f, "%.1f")) OverlayConfig_MarkDirty();
-        ImGui::PopID();
-
-        if (!config.easynorecoil) ImGui::EndDisabled();
         OverlayUI::EndSection();
     }
 
@@ -719,8 +783,12 @@ void draw_mouse()
         OverlayUI::EndSection();
     }
 
-    if (prev_fovX != config.fovX ||
-        prev_fovY != config.fovY ||
+    if (prev_enable_dynamic_fov != config.enable_dynamic_fov ||
+        prev_fovX_hipfire != config.fovX_hipfire ||
+        prev_fovY_hipfire != config.fovY_hipfire ||
+        prev_fovX_ads != config.fovX_ads ||
+        prev_fovY_ads != config.fovY_ads ||
+        prev_hipfire_smooth != config.hipfire_smooth ||
         prev_minSpeedMultiplier != config.minSpeedMultiplier ||
         prev_maxSpeedMultiplier != config.maxSpeedMultiplier ||
         prev_predictionInterval != config.predictionInterval ||
@@ -739,8 +807,12 @@ void draw_mouse()
         prev_speedCurveExponent != config.speedCurveExponent ||
         prev_snapBoostFactor != config.snapBoostFactor)
     {
-        prev_fovX = config.fovX;
-        prev_fovY = config.fovY;
+        prev_enable_dynamic_fov = config.enable_dynamic_fov;
+        prev_fovX_hipfire = config.fovX_hipfire;
+        prev_fovY_hipfire = config.fovY_hipfire;
+        prev_fovX_ads = config.fovX_ads;
+        prev_fovY_ads = config.fovY_ads;
+        prev_hipfire_smooth = config.hipfire_smooth;
         prev_minSpeedMultiplier = config.minSpeedMultiplier;
         prev_maxSpeedMultiplier = config.maxSpeedMultiplier;
         prev_predictionInterval = config.predictionInterval;
@@ -759,12 +831,23 @@ void draw_mouse()
         prev_speedCurveExponent = config.speedCurveExponent;
         prev_snapBoostFactor = config.snapBoostFactor;
 
+        int pass_fovX = config.enable_dynamic_fov ? (zooming.load() ? config.fovX_ads : config.fovX_hipfire) : config.fovX_ads;
+        int pass_fovY = config.enable_dynamic_fov ? (zooming.load() ? config.fovY_ads : config.fovY_hipfire) : config.fovY_ads;
+        
+        float pass_minSpeed = config.minSpeedMultiplier;
+        float pass_maxSpeed = config.maxSpeedMultiplier;
+        if (config.enable_dynamic_fov && !zooming.load())
+        {
+            pass_minSpeed *= config.hipfire_smooth;
+            pass_maxSpeed *= config.hipfire_smooth;
+        }
+
         globalMouseThread->updateConfig(
             config.detection_resolution,
-            config.fovX,
-            config.fovY,
-            config.minSpeedMultiplier,
-            config.maxSpeedMultiplier,
+            pass_fovX,
+            pass_fovY,
+            pass_minSpeed,
+            pass_maxSpeed,
             config.predictionInterval,
             config.auto_shoot,
             config.bScope_multiplier);
@@ -784,12 +867,23 @@ void draw_mouse()
         prev_wind_M = config.wind_M;
         prev_wind_D = config.wind_D;
 
+        int pass_fovX = config.enable_dynamic_fov ? (zooming.load() ? config.fovX_ads : config.fovX_hipfire) : config.fovX_ads;
+        int pass_fovY = config.enable_dynamic_fov ? (zooming.load() ? config.fovY_ads : config.fovY_hipfire) : config.fovY_ads;
+
+        float pass_minSpeed = config.minSpeedMultiplier;
+        float pass_maxSpeed = config.maxSpeedMultiplier;
+        if (config.enable_dynamic_fov && !zooming.load())
+        {
+            pass_minSpeed *= config.hipfire_smooth;
+            pass_maxSpeed *= config.hipfire_smooth;
+        }
+
         globalMouseThread->updateConfig(
             config.detection_resolution,
-            config.fovX,
-            config.fovY,
-            config.minSpeedMultiplier,
-            config.maxSpeedMultiplier,
+            pass_fovX,
+            pass_fovY,
+            pass_minSpeed,
+            pass_maxSpeed,
             config.predictionInterval,
             config.auto_shoot,
             config.bScope_multiplier);
@@ -803,12 +897,23 @@ void draw_mouse()
         prev_auto_shoot = config.auto_shoot;
         prev_bScope_multiplier = config.bScope_multiplier;
 
+        int pass_fovX = config.enable_dynamic_fov ? (zooming.load() ? config.fovX_ads : config.fovX_hipfire) : config.fovX_ads;
+        int pass_fovY = config.enable_dynamic_fov ? (zooming.load() ? config.fovY_ads : config.fovY_hipfire) : config.fovY_ads;
+
+        float pass_minSpeed = config.minSpeedMultiplier;
+        float pass_maxSpeed = config.maxSpeedMultiplier;
+        if (config.enable_dynamic_fov && !zooming.load())
+        {
+            pass_minSpeed *= config.hipfire_smooth;
+            pass_maxSpeed *= config.hipfire_smooth;
+        }
+
         globalMouseThread->updateConfig(
             config.detection_resolution,
-            config.fovX,
-            config.fovY,
-            config.minSpeedMultiplier,
-            config.maxSpeedMultiplier,
+            pass_fovX,
+            pass_fovY,
+            pass_minSpeed,
+            pass_maxSpeed,
             config.predictionInterval,
             config.auto_shoot,
             config.bScope_multiplier);

--- a/sunone_aimbot_2/overlay/draw_mouse.cpp
+++ b/sunone_aimbot_2/overlay/draw_mouse.cpp
@@ -273,7 +273,7 @@ void draw_mouse()
                 config.active_game = name;
                 OverlayConfig_MarkDirty();
                 input_method_changed.store(true);
-                new_profile_name[0] = '\0'; // clear
+                new_profile_name[0] = '\0';
             }
         }
 
@@ -298,28 +298,37 @@ void draw_mouse()
         OverlayUI::EndSection();
     }
 
-    if (OverlayUI::BeginSection("Easy No Recoil", "mouse_section_easy_no_recoil"))
+    if (OverlayUI::BeginSection("Recoil Control", "mouse_section_recoil"))
     {
-        ImGui::Checkbox("Easy No Recoil", &config.easynorecoil);
-        if (!config.easynorecoil)
-        {
-            ImGui::BeginDisabled();
-        }
+        if (ImGui::Checkbox("Easy No Recoil", &config.easynorecoil)) OverlayConfig_MarkDirty();
+        if (!config.easynorecoil) ImGui::BeginDisabled();
 
-        ImGui::SliderFloat("No Recoil Strength", &config.easynorecoilstrength, 0.1f, 500.0f, "%.1f");
-        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Left/Right Arrow keys: Adjust recoil strength by 10");
+        ImGui::Dummy(ImVec2(0.0f, 5.0f));
+        ImGui::Text("Vertical Compensation:");
+        if (ImGui::SliderFloat("Pull Down Strength", &config.recoil_pull_down_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
 
-        if (config.easynorecoilstrength >= 100.0f)
-        {
-            ImGui::TextColored(ImVec4(255, 255, 0, 255), "WARNING: High recoil strength may be detected.");
-        }
+        ImGui::Separator();
+        ImGui::PushID("recoil_left");
+        ImGui::Text("Left Compensation:");
+        if (ImGui::SliderFloat("Delay (ms)", &config.recoil_pull_left_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
+        if (ImGui::SliderFloat("Pull Left Strength", &config.recoil_pull_left_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
+        ImGui::PopID();
 
-        if (!config.easynorecoil)
-        {
-            ImGui::EndDisabled();
-            ImGui::TextDisabled("Enable Easy No Recoil to edit settings.");
-        }
+        ImGui::Separator();
+        ImGui::PushID("recoil_right");
+        ImGui::Text("Right Compensation:");
+        if (ImGui::SliderFloat("Delay (ms)", &config.recoil_pull_right_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
+        if (ImGui::SliderFloat("Pull Right Strength", &config.recoil_pull_right_strength, 0.0f, 20.0f, "%.2f")) OverlayConfig_MarkDirty();
+        ImGui::PopID();
 
+        ImGui::Separator();
+        ImGui::PushID("recoil_sway");
+        ImGui::Text("Humanization (Sway):");
+        if (ImGui::SliderFloat("Sway Speed", &config.recoil_sway_speed, 0.0f, 20.0f, "%.1f")) OverlayConfig_MarkDirty();
+        if (ImGui::SliderFloat("Sway Amount", &config.recoil_sway, 0.0f, 20.0f, "%.1f")) OverlayConfig_MarkDirty();
+        ImGui::PopID();
+
+        if (!config.easynorecoil) ImGui::EndDisabled();
         OverlayUI::EndSection();
     }
 

--- a/sunone_aimbot_2/overlay/draw_mouse.cpp
+++ b/sunone_aimbot_2/overlay/draw_mouse.cpp
@@ -371,26 +371,38 @@ void draw_mouse()
         OverlayUI::EndSection();
     }
 
-    if (OverlayUI::BeginSection("Easy No Recoil", "mouse_section_easy_no_recoil"))
+    if (OverlayUI::BeginSection("Anti-Recoil", "mouse_section_recoil"))
     {
-        ImGui::Checkbox("Easy No Recoil", &config.easynorecoil);
-        if (!config.easynorecoil)
-        {
-            ImGui::BeginDisabled();
+        if (ImGui::Checkbox("Enable Anti-Recoil", &config.easynorecoil)) {
+            OverlayConfig_MarkDirty();
         }
 
-        ImGui::SliderFloat("No Recoil Strength", &config.easynorecoilstrength, 0.1f, 500.0f, "%.1f");
-        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "Left/Right Arrow keys: Adjust recoil strength by 10");
-
-        if (config.easynorecoilstrength >= 100.0f)
+        if (config.easynorecoil)
         {
-            ImGui::TextColored(ImVec4(255, 255, 0, 255), "WARNING: High recoil strength may be detected.");
-        }
+            ImGui::Dummy(ImVec2(0.0f, 5.0f));
+            ImGui::Text("Vertical Compensation:");
+            if (ImGui::SliderFloat("Pull Down Strength", &config.recoil_pull_down_strength, 0.0f, 100.0f, "%.2f")) OverlayConfig_MarkDirty();
 
-        if (!config.easynorecoil)
-        {
-            ImGui::EndDisabled();
-            ImGui::TextDisabled("Enable Easy No Recoil to edit settings.");
+            ImGui::Separator();
+            ImGui::PushID("recoil_left");
+            ImGui::Text("Left Compensation:");
+            if (ImGui::SliderFloat("Delay (ms)##Left", &config.recoil_pull_left_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
+            if (ImGui::SliderFloat("Strength##Left", &config.recoil_pull_left_strength, 0.0f, 50.0f, "%.2f")) OverlayConfig_MarkDirty();
+            ImGui::PopID();
+
+            ImGui::Separator();
+            ImGui::PushID("recoil_right");
+            ImGui::Text("Right Compensation:");
+            if (ImGui::SliderFloat("Delay (ms)##Right", &config.recoil_pull_right_delay, 0.0f, 1000.0f, "%.0f")) OverlayConfig_MarkDirty();
+            if (ImGui::SliderFloat("Strength##Right", &config.recoil_pull_right_strength, 0.0f, 50.0f, "%.2f")) OverlayConfig_MarkDirty();
+            ImGui::PopID();
+
+            ImGui::Separator();
+            ImGui::PushID("recoil_sway");
+            ImGui::Text("Humanization (Sway):");
+            if (ImGui::SliderFloat("Sway Speed", &config.recoil_sway_speed, 0.0f, 50.0f, "%.1f")) OverlayConfig_MarkDirty();
+            if (ImGui::SliderFloat("Sway Amount", &config.recoil_sway, 0.0f, 50.0f, "%.1f")) OverlayConfig_MarkDirty();
+            ImGui::PopID();
         }
 
         OverlayUI::EndSection();

--- a/sunone_aimbot_2/overlay/overlay.cpp
+++ b/sunone_aimbot_2/overlay/overlay.cpp
@@ -550,6 +550,7 @@ void OverlayThread()
     SetupImGui();
 
     bool show_overlay = false;
+    int frames_to_clear = 0;
 
     for (const auto& pair : KeyCodes::key_code_map) key_names.push_back(pair.first);
     std::sort(key_names.begin(), key_names.end());
@@ -591,6 +592,10 @@ void OverlayThread()
             show_overlay = !show_overlay;
             g_menuOpen = show_overlay; 
             
+            if (!show_overlay) {
+                frames_to_clear = 2;
+            }
+
             LONG exStyle = GetWindowLong(g_hwnd, GWL_EXSTYLE);
             if (show_overlay)
             {
@@ -608,7 +613,7 @@ void OverlayThread()
         bool should_render = false;
         bool use_vsync = false; 
 
-        if (show_overlay)
+        if (show_overlay || frames_to_clear > 0)
         {
             should_render = true;
             use_vsync = true;
@@ -753,6 +758,10 @@ void OverlayThread()
             HRESULT result = g_pSwapChain->Present(0, 0);
             if (result == DXGI_STATUS_OCCLUDED || result == DXGI_ERROR_ACCESS_LOST)
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        if (frames_to_clear > 0) {
+            frames_to_clear--;
         }
     }
 

--- a/sunone_aimbot_2/overlay/overlay.cpp
+++ b/sunone_aimbot_2/overlay/overlay.cpp
@@ -5,13 +5,13 @@
 #endif
 #include <winsock2.h>
 #include <Windows.h>
-
 #include <tchar.h>
 #include <thread>
 #include <mutex>
 #include <atomic>
 #include <d3d11.h>
 #include <dxgi.h>
+#include <dxgi1_2.h>
 #include <dwmapi.h>
 #include <dcomp.h>
 #include <vector>
@@ -43,6 +43,9 @@
 #pragma comment(lib, "dcomp.lib")
 #pragma comment(lib, "d3d11.lib")
 
+#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
+#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
+
 ID3D11Device* g_pd3dDevice = NULL;
 ID3D11DeviceContext* g_pd3dDeviceContext = NULL;
 IDXGISwapChain1* g_pSwapChain = NULL;
@@ -55,6 +58,9 @@ HWND g_hwnd = NULL;
 extern Config config;
 extern std::mutex configMutex;
 extern std::atomic<bool> shouldExit;
+
+extern void draw_crosshair_settings();
+extern void RenderActiveCrosshair(int screenWidth, int screenHeight);
 
 bool CreateDeviceD3D(HWND hWnd);
 void CleanupDeviceD3D();
@@ -73,11 +79,11 @@ static const int MIN_EDITOR_OPACITY = 220;
 int overlayWidth = 0;
 int overlayHeight = 0;
 
-static const int DRAG_BAR_HEIGHT_PX = 30;
-static const int MIN_OVERLAY_W = 420;
-static const int MIN_OVERLAY_H = 300;
-static const int RESIZE_BORDER_PX = 8;
-static const int WORKAREA_MARGIN_PX = 20;
+float g_menuX = 0;
+float g_menuY = 0;
+float g_menuW = 720;
+float g_menuH = 500;
+bool g_menuOpen = false;
 
 static bool g_autoResizeEnabled = true;
 static ImGuiStyle g_baseStyle{};
@@ -89,11 +95,6 @@ std::vector<std::string> key_names;
 std::vector<const char*> key_names_cstrs;
 
 ID3D11ShaderResourceView* body_texture = nullptr;
-
-static UINT GetDpiForWindowSafe(HWND hwnd);
-static RECT GetOverlayWorkArea(HWND hwnd);
-static void ClampOverlayToWorkArea(HWND hwnd, int& x, int& y, int& w, int& h);
-static void EnsureOverlayInsideWorkArea(HWND hwnd);
 
 void load_body_texture();
 void release_body_texture();
@@ -122,8 +123,7 @@ static float ComputeRuntimeUiScale(float windowW, float windowH)
 
 static void ApplyRuntimeUiScale(float windowW, float windowH)
 {
-    if (!g_baseStyleReady)
-        return;
+    if (!g_baseStyleReady) return;
 
     ImGuiIO& io = ImGui::GetIO();
     const float targetScale = ComputeRuntimeUiScale(windowW, windowH);
@@ -137,33 +137,6 @@ static void ApplyRuntimeUiScale(float windowW, float windowH)
     io.FontGlobalScale = targetScale;
 }
 
-static void TryAutoResizeOverlay(float extraContentWidth)
-{
-    if (!g_hwnd || !g_autoResizeEnabled)
-        return;
-
-    // Keep auto-grow only for severe horizontal overflow.
-    if (extraContentWidth <= 120.0f)
-        return;
-
-    const int extraPx = ClampInt(static_cast<int>(extraContentWidth + 0.5f), 0, 260);
-    if (extraPx <= 0)
-        return;
-
-    RECT wndRect{};
-    ::GetWindowRect(g_hwnd, &wndRect);
-
-    int targetX = wndRect.left;
-    int targetY = wndRect.top;
-    int targetW = overlayWidth + extraPx;
-    int targetH = overlayHeight; // Height is user-controlled; content area already scrolls vertically.
-
-    ClampOverlayToWorkArea(g_hwnd, targetX, targetY, targetW, targetH);
-
-    if (targetW != overlayWidth || targetX != wndRect.left || targetY != wndRect.top)
-        SetWindowPos(g_hwnd, NULL, targetX, targetY, targetW, targetH, SWP_NOZORDER);
-}
-
 void Overlay_SetOpacity(int opacity255)
 {
     if (!g_hwnd) return;
@@ -174,27 +147,21 @@ void Overlay_SetOpacity(int opacity255)
     if ((exStyle & WS_EX_LAYERED) == 0)
         SetWindowLong(g_hwnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
 
-    SetLayeredWindowAttributes(g_hwnd, 0, (BYTE)opacity255, LWA_ALPHA);
+    SetLayeredWindowAttributes(g_hwnd, RGB(0, 0, 0), 0, LWA_COLORKEY);
 }
 
 static void Overlay_SetDisplayAffinity(HWND hwnd, bool excludeFromCapture)
 {
-    if (!hwnd)
-        return;
+    if (!hwnd) return;
 
     const DWORD wanted = excludeFromCapture ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
-    if (SetWindowDisplayAffinity(hwnd, wanted))
-        return;
+    if (SetWindowDisplayAffinity(hwnd, wanted)) return;
 
     if (excludeFromCapture)
     {
-        const DWORD err = GetLastError();
-        std::cerr << "[OverlayUI] SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE) failed, err=" << err
-                  << ". Trying WDA_MONITOR fallback." << std::endl;
         if (!SetWindowDisplayAffinity(hwnd, WDA_MONITOR))
         {
-            std::cerr << "[OverlayUI] SetWindowDisplayAffinity(WDA_MONITOR) failed, err="
-                      << GetLastError() << std::endl;
+            std::cerr << "[OverlayUI] SetWindowDisplayAffinity failed." << std::endl;
         }
     }
 }
@@ -204,8 +171,7 @@ void Overlay_ApplyCaptureExclusion()
     Overlay_SetDisplayAffinity(g_hwnd, config.overlay_exclude_from_capture);
 }
 
-static inline ImVec4 RGBA(int r, int g, int b, int a = 255)
-{
+static inline ImVec4 RGBA(int r, int g, int b, int a = 255) {
     return ImVec4(r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
 }
 
@@ -325,15 +291,16 @@ struct OverlayTabItem
 };
 
 static const OverlayTabItem kOverlayTabs[] = {
-    { "Capture",       "Core",    "Frame source and input feed settings.",              draw_capture_settings },
-    { "Target",        "Core",    "Target selection and aim point offsets.",             draw_target },
-    { "Mouse",         "Core",    "Mouse behavior, input backend and motion profile.",   draw_mouse },
-    { "AI",            "Core",    "Model and detector thresholds.",                      draw_ai },
-    { "Buttons",       "Control", "Hotkeys for features and runtime actions.",           draw_buttons },
-    { "Overlay",       "Control", "Editor appearance and privacy options.",              draw_overlay },
-    { "Game Overlay",  "Control", "In-game render visuals and simulation options.",      draw_game_overlay_settings },
-    { "Stats",         "Monitor", "Performance and timing graphs.",                      draw_stats },
-    { "Debug",         "Monitor", "Screenshot bindings and diagnostics.",                draw_debug },
+    { "Capture",           "Core",    "Frame source and input feed settings.",              draw_capture_settings },
+    { "Target",            "Core",    "Target selection and aim point offsets.",            draw_target },
+    { "Mouse",             "Core",    "Mouse behavior, input backend and motion profile.",  draw_mouse },
+    { "AI",                "Core",    "Model and detector thresholds.",                     draw_ai },
+    { "Buttons",           "Control", "Hotkeys for features and runtime actions.",          draw_buttons },
+    { "Overlay",           "Control", "Editor appearance and privacy options.",             draw_overlay },
+    { "Game Overlay",      "Control", "In-game render visuals and simulation options.",     draw_game_overlay_settings },
+    { "Crosshair Overlay", "Control", "Dynamic crosshair configuration and auto-color.",    draw_crosshair_settings },
+    { "Stats",             "Monitor", "Performance and timing graphs.",                     draw_stats },
+    { "Debug",             "Monitor", "Screenshot bindings and diagnostics.",               draw_debug },
 };
 
 static void DrawMainPanelBackground(const ImVec2& pos, const ImVec2& size)
@@ -349,8 +316,7 @@ static bool DrawSidebarTabButton(const char* label, bool selected)
     const ImVec2 pos = ImGui::GetCursorScreenPos();
     const ImGuiStyle& style = ImGui::GetStyle();
     ImVec2 size = ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetFrameHeight() + style.ItemSpacing.y * 0.15f);
-    if (size.x < 1.0f)
-        size.x = 1.0f;
+    if (size.x < 1.0f) size.x = 1.0f;
 
     const std::string id = std::string("##nav_") + label;
     const bool pressed = ImGui::InvisibleButton(id.c_str(), size);
@@ -377,94 +343,6 @@ static bool DrawSidebarTabButton(const char* label, bool selected)
     return pressed;
 }
 
-static UINT GetDpiForWindowSafe(HWND hwnd)
-{
-    UINT dpi = 96;
-    HMODULE user32 = ::GetModuleHandleW(L"user32.dll");
-    if (user32)
-    {
-        auto pGetDpiForWindow = (UINT(WINAPI*)(HWND))::GetProcAddress(user32, "GetDpiForWindow");
-        if (pGetDpiForWindow)
-            dpi = pGetDpiForWindow(hwnd);
-    }
-    return dpi;
-}
-
-static RECT GetOverlayWorkArea(HWND hwnd)
-{
-    RECT work{};
-    HMONITOR monitor = nullptr;
-
-    if (hwnd)
-    {
-        monitor = ::MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    }
-    else
-    {
-        POINT pt{};
-        ::GetCursorPos(&pt);
-        monitor = ::MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-    }
-
-    MONITORINFO mi{};
-    mi.cbSize = sizeof(mi);
-    if (monitor && ::GetMonitorInfo(monitor, &mi))
-        return mi.rcWork;
-
-    work.left = 0;
-    work.top = 0;
-    work.right = ::GetSystemMetrics(SM_CXSCREEN);
-    work.bottom = ::GetSystemMetrics(SM_CYSCREEN);
-    return work;
-}
-
-static void ClampOverlayToWorkArea(HWND hwnd, int& x, int& y, int& w, int& h)
-{
-    const RECT work = GetOverlayWorkArea(hwnd);
-    const UINT dpi = hwnd ? GetDpiForWindowSafe(hwnd) : 96;
-
-    const int minW = ::MulDiv(MIN_OVERLAY_W, (int)dpi, 96);
-    const int minH = ::MulDiv(MIN_OVERLAY_H, (int)dpi, 96);
-
-    const int workW = OtherTools::MaxInt(1, static_cast<int>(work.right - work.left - WORKAREA_MARGIN_PX));
-    const int workH = OtherTools::MaxInt(1, static_cast<int>(work.bottom - work.top - WORKAREA_MARGIN_PX));
-
-    const int maxW = OtherTools::MaxInt(minW, workW);
-    const int maxH = OtherTools::MaxInt(minH, workH);
-
-    w = ClampInt(w, minW, maxW);
-    h = ClampInt(h, minH, maxH);
-
-    const int maxX = OtherTools::MaxInt(static_cast<int>(work.left), static_cast<int>(work.right - w));
-    const int maxY = OtherTools::MaxInt(static_cast<int>(work.top), static_cast<int>(work.bottom - h));
-    x = ClampInt(x, static_cast<int>(work.left), maxX);
-    y = ClampInt(y, static_cast<int>(work.top), maxY);
-}
-
-static void EnsureOverlayInsideWorkArea(HWND hwnd)
-{
-    if (!hwnd)
-        return;
-
-    RECT wndRect{};
-    ::GetWindowRect(hwnd, &wndRect);
-
-    const int oldW = overlayWidth;
-    const int oldH = overlayHeight;
-
-    int x = wndRect.left;
-    int y = wndRect.top;
-    int w = overlayWidth;
-    int h = overlayHeight;
-    ClampOverlayToWorkArea(hwnd, x, y, w, h);
-
-    overlayWidth = w;
-    overlayHeight = h;
-
-    if (x != wndRect.left || y != wndRect.top || w != oldW || h != oldH)
-        ::SetWindowPos(hwnd, NULL, x, y, w, h, SWP_NOZORDER);
-}
-
 bool InitializeBlendState()
 {
     D3D11_BLEND_DESC blendDesc;
@@ -481,8 +359,7 @@ bool InitializeBlendState()
     blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
 
     HRESULT hr = g_pd3dDevice->CreateBlendState(&blendDesc, &g_pBlendState);
-    if (FAILED(hr))
-        return false;
+    if (FAILED(hr)) return false;
 
     float blendFactor[4] = { 0.f, 0.f, 0.f, 0.f };
     g_pd3dDeviceContext->OMSetBlendState(g_pBlendState, blendFactor, 0xffffffff);
@@ -492,61 +369,23 @@ bool InitializeBlendState()
 bool CreateDeviceD3D(HWND hWnd)
 {
     UINT createDeviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-
     D3D_FEATURE_LEVEL featureLevel;
-    const D3D_FEATURE_LEVEL featureLevelArray[] = {
-        D3D_FEATURE_LEVEL_11_0,
-        D3D_FEATURE_LEVEL_10_0,
-    };
+    const D3D_FEATURE_LEVEL featureLevelArray[] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0 };
 
-    HRESULT hr = D3D11CreateDevice(
-        nullptr,
-        D3D_DRIVER_TYPE_HARDWARE,
-        nullptr,
-        createDeviceFlags,
-        featureLevelArray,
-        ARRAYSIZE(featureLevelArray),
-        D3D11_SDK_VERSION,
-        &g_pd3dDevice,
-        &featureLevel,
-        &g_pd3dDeviceContext);
-
-    if (FAILED(hr))
-        return false;
+    HRESULT hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, createDeviceFlags, featureLevelArray, ARRAYSIZE(featureLevelArray), D3D11_SDK_VERSION, &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext);
+    if (FAILED(hr)) return false;
 
     IDXGIDevice* dxgiDev = nullptr;
     hr = g_pd3dDevice->QueryInterface(IID_PPV_ARGS(&dxgiDev));
-    if (FAILED(hr) || !dxgiDev)
-        return false;
+    if (FAILED(hr) || !dxgiDev) return false;
 
     IDXGIAdapter* adapter = nullptr;
     hr = dxgiDev->GetAdapter(&adapter);
-    if (FAILED(hr) || !adapter)
-    {
-        dxgiDev->Release();
-        return false;
-    }
+    if (FAILED(hr) || !adapter) { dxgiDev->Release(); return false; }
 
     IDXGIFactory2* factory2 = nullptr;
-    {
-        IDXGIFactory* baseFactory = nullptr;
-        hr = adapter->GetParent(IID_PPV_ARGS(&baseFactory));
-        if (FAILED(hr) || !baseFactory)
-        {
-            adapter->Release();
-            dxgiDev->Release();
-            return false;
-        }
-        hr = baseFactory->QueryInterface(IID_PPV_ARGS(&factory2));
-        baseFactory->Release();
-    }
-
-    if (FAILED(hr) || !factory2)
-    {
-        adapter->Release();
-        dxgiDev->Release();
-        return false;
-    }
+    hr = adapter->GetParent(IID_PPV_ARGS(&factory2));
+    if (FAILED(hr) || !factory2) { adapter->Release(); dxgiDev->Release(); return false; }
 
     DXGI_SWAP_CHAIN_DESC1 scd = {};
     scd.Width = overlayWidth;
@@ -555,51 +394,17 @@ bool CreateDeviceD3D(HWND hWnd)
     scd.SampleDesc.Count = 1;
     scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     scd.BufferCount = 2;
-    scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-    scd.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
-    scd.Scaling = DXGI_SCALING_STRETCH;
+    scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
-    hr = factory2->CreateSwapChainForComposition(
-        g_pd3dDevice,
-        &scd,
-        nullptr,
-        &g_pSwapChain);
-
-    factory2->Release();
+    hr = factory2->CreateSwapChainForHwnd(g_pd3dDevice, hWnd, &scd, nullptr, nullptr, &g_pSwapChain);
+    
+    factory2->Release(); 
     adapter->Release();
-
-    if (FAILED(hr) || !g_pSwapChain)
-    {
-        dxgiDev->Release();
-        return false;
-    }
-
-    hr = DCompositionCreateDevice(dxgiDev, IID_PPV_ARGS(&g_dcompDevice));
     dxgiDev->Release();
-    if (FAILED(hr) || !g_dcompDevice)
-        return false;
 
-    hr = g_dcompDevice->CreateTargetForHwnd(hWnd, TRUE, &g_dcompTarget);
-    if (FAILED(hr) || !g_dcompTarget)
-        return false;
+    if (FAILED(hr) || !g_pSwapChain) return false;
 
-    hr = g_dcompDevice->CreateVisual(&g_dcompVisual);
-    if (FAILED(hr) || !g_dcompVisual)
-        return false;
-
-    hr = g_dcompVisual->SetContent(g_pSwapChain);
-    if (FAILED(hr))
-        return false;
-
-    hr = g_dcompTarget->SetRoot(g_dcompVisual);
-    if (FAILED(hr))
-        return false;
-
-    g_dcompDevice->Commit();
-
-    if (!InitializeBlendState())
-        return false;
-
+    if (!InitializeBlendState()) return false;
     CreateRenderTarget();
     return true;
 }
@@ -620,11 +425,6 @@ void CleanupRenderTarget()
 void CleanupDeviceD3D()
 {
     CleanupRenderTarget();
-
-    if (g_dcompVisual) { g_dcompVisual->Release(); g_dcompVisual = NULL; }
-    if (g_dcompTarget) { g_dcompTarget->Release(); g_dcompTarget = NULL; }
-    if (g_dcompDevice) { g_dcompDevice->Release(); g_dcompDevice = NULL; }
-
     if (g_pSwapChain) { g_pSwapChain->Release(); g_pSwapChain = NULL; }
     if (g_pd3dDeviceContext) { g_pd3dDeviceContext->Release(); g_pd3dDeviceContext = NULL; }
     if (g_pd3dDevice) { g_pd3dDevice->Release(); g_pd3dDevice = NULL; }
@@ -633,85 +433,35 @@ void CleanupDeviceD3D()
 
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    switch (msg)
-    {
-        case WM_NCHITTEST:
-        {
-            POINT pt = { (int)(short)LOWORD(lParam), (int)(short)HIWORD(lParam) };
-            ::ScreenToClient(hWnd, &pt);
-
-            RECT rc;
-            ::GetClientRect(hWnd, &rc);
-
-            const UINT dpi = GetDpiForWindowSafe(hWnd);
-            const int border = ::MulDiv(RESIZE_BORDER_PX, (int)dpi, 96);
-            const bool left = pt.x < rc.left + border;
-            const bool right = pt.x >= rc.right - border;
-            const bool top = pt.y < rc.top + border;
-            const bool bottom = pt.y >= rc.bottom - border;
-
-            if (top && left) return HTTOPLEFT;
-            if (top && right) return HTTOPRIGHT;
-            if (bottom && left) return HTBOTTOMLEFT;
-            if (bottom && right) return HTBOTTOMRIGHT;
-            if (left) return HTLEFT;
-            if (right) return HTRIGHT;
-            if (top) return HTTOP;
-            if (bottom) return HTBOTTOM;
-
-            if (pt.y >= rc.top && pt.y < rc.top + DRAG_BAR_HEIGHT_PX)
-                return HTCAPTION;
-
-            return HTCLIENT;
-        }
-        case WM_GETMINMAXINFO:
-        {
-            MINMAXINFO* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
-            const UINT dpi = GetDpiForWindowSafe(hWnd);
-            const int minW = ::MulDiv(MIN_OVERLAY_W, (int)dpi, 96);
-            const int minH = ::MulDiv(MIN_OVERLAY_H, (int)dpi, 96);
-            const RECT work = GetOverlayWorkArea(hWnd);
-            const int maxW = OtherTools::MaxInt(minW, static_cast<int>((work.right - work.left) - WORKAREA_MARGIN_PX));
-            const int maxH = OtherTools::MaxInt(minH, static_cast<int>((work.bottom - work.top) - WORKAREA_MARGIN_PX));
-            mmi->ptMinTrackSize.x = minW;
-            mmi->ptMinTrackSize.y = minH;
-            if (maxW > 0) mmi->ptMaxTrackSize.x = maxW;
-            if (maxH > 0) mmi->ptMaxTrackSize.y = maxH;
-            return 0;
-        }
-    }
-
     if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
         return true;
 
     switch (msg)
     {
-    case WM_EXITSIZEMOVE:
-        g_autoResizeEnabled = false;
-        EnsureOverlayInsideWorkArea(hWnd);
-        return 0;
+    case WM_NCHITTEST:
+    {
+        if (!g_menuOpen) return HTTRANSPARENT; 
 
-    case WM_DISPLAYCHANGE:
-        EnsureOverlayInsideWorkArea(hWnd);
-        return 0;
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        ::ScreenToClient(hWnd, &pt);
 
-    case WM_DPICHANGED:
-        EnsureOverlayInsideWorkArea(hWnd);
-        return 0;
-
+        if (pt.x >= g_menuX && pt.x <= g_menuX + g_menuW &&
+            pt.y >= g_menuY && pt.y <= g_menuY + g_menuH)
+        {
+            return HTCLIENT;
+        }
+        
+        return HTTRANSPARENT;
+    }
     case WM_SIZE:
         if (g_pd3dDevice != NULL && wParam != SIZE_MINIMIZED)
         {
-            const UINT width = (UINT)LOWORD(lParam);
-            const UINT height = (UINT)HIWORD(lParam);
-
-            overlayWidth = (int)width;
-            overlayHeight = (int)height;
+            overlayWidth = (UINT)LOWORD(lParam);
+            overlayHeight = (UINT)HIWORD(lParam);
 
             CleanupRenderTarget();
-            g_pSwapChain->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);
+            g_pSwapChain->ResizeBuffers(0, overlayWidth, overlayHeight, DXGI_FORMAT_UNKNOWN, 0);
             CreateRenderTarget();
-            if (g_dcompDevice) g_dcompDevice->Commit();
         }
         return 0;
 
@@ -736,13 +486,13 @@ void SetupImGui()
     fontConfig.OversampleH = 3;
     fontConfig.OversampleV = 2;
     fontConfig.PixelSnapH = true;
-    if (!io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\segoeui.ttf", 14.0f, &fontConfig))
-    {
+    
+    io.IniFilename = "sunone_ui_layout.ini"; 
+    io.LogFilename = nullptr;
+
+    if (!io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\segoeui.ttf", 14.0f, &fontConfig)) {
         io.Fonts->AddFontDefault();
     }
-
-    io.IniFilename = nullptr;
-    io.LogFilename = nullptr;
 
     ImGui_ImplWin32_Init(g_hwnd);
     ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
@@ -756,67 +506,25 @@ void SetupImGui()
 
 bool CreateOverlayWindow()
 {
-    overlayWidth = BASE_OVERLAY_WIDTH;
-    overlayHeight = BASE_OVERLAY_HEIGHT;
+    overlayWidth = GetSystemMetrics(SM_CXSCREEN);
+    overlayHeight = GetSystemMetrics(SM_CYSCREEN);
 
-    {
-        int x = 0;
-        int y = 0;
-        int w = overlayWidth;
-        int h = overlayHeight;
-        ClampOverlayToWorkArea(nullptr, x, y, w, h);
-        overlayWidth = w;
-        overlayHeight = h;
-    }
-
-    WNDCLASSEX wc = {
-        sizeof(WNDCLASSEX),
-        CS_CLASSDC,
-        WndProc,
-        0L,
-        0L,
-        GetModuleHandle(NULL),
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        _T("Chrome"),
-        NULL
-    };
+    WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, WndProc, 0L, 0L, GetModuleHandle(NULL), NULL, NULL, NULL, NULL, _T("Chrome"), NULL };
     ::RegisterClassEx(&wc);
 
     const DWORD exStyle = WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_LAYERED;
     const DWORD style = WS_POPUP;
 
-    RECT wr = { 0, 0, overlayWidth, overlayHeight };
-    ::AdjustWindowRectEx(&wr, style, FALSE, exStyle);
-
-    const int wndW = wr.right - wr.left;
-    const int wndH = wr.bottom - wr.top;
-
     g_hwnd = ::CreateWindowEx(
-        exStyle,
+        exStyle | WS_EX_TRANSPARENT, 
         wc.lpszClassName, _T("Chrome"),
         style,
-        0, 0, wndW, wndH,
+        0, 0, overlayWidth, overlayHeight,
         NULL, NULL, wc.hInstance, NULL);
 
-    if (g_hwnd == NULL)
-        return false;
+    if (g_hwnd == NULL) return false;
 
-    EnsureOverlayInsideWorkArea(g_hwnd);
-
-    BOOL dwm = FALSE;
-    if (SUCCEEDED(DwmIsCompositionEnabled(&dwm)) && dwm)
-    {
-        MARGINS m = { -1, -1, -1, -1 };
-        DwmExtendFrameIntoClientArea(g_hwnd, &m);
-    }
-
-    if (config.overlay_opacity < MIN_EDITOR_OPACITY)  config.overlay_opacity = MIN_EDITOR_OPACITY;
-    if (config.overlay_opacity >= 256) config.overlay_opacity = 255;
-
-    Overlay_SetOpacity(config.overlay_opacity);
+    Overlay_SetOpacity(255);
 
     if (!CreateDeviceD3D(g_hwnd))
     {
@@ -825,6 +533,7 @@ bool CreateOverlayWindow()
         return false;
     }
 
+    SetWindowPos(g_hwnd, HWND_TOPMOST, 0, 0, overlayWidth, overlayHeight, SWP_SHOWWINDOW);
     Overlay_ApplyCaptureExclusion();
 
     return true;
@@ -842,13 +551,10 @@ void OverlayThread()
 
     bool show_overlay = false;
 
-    for (const auto& pair : KeyCodes::key_code_map)
-        key_names.push_back(pair.first);
-
+    for (const auto& pair : KeyCodes::key_code_map) key_names.push_back(pair.first);
     std::sort(key_names.begin(), key_names.end());
     key_names_cstrs.reserve(key_names.size());
-    for (const auto& name : key_names)
-        key_names_cstrs.push_back(name.c_str());
+    for (const auto& name : key_names) key_names_cstrs.push_back(name.c_str());
 
     availableModels = getAvailableModels();
 
@@ -856,6 +562,9 @@ void OverlayThread()
     ZeroMemory(&msg, sizeof(msg));
     bool lastExcludeFromCapture = config.overlay_exclude_from_capture;
     Overlay_SetDisplayAffinity(g_hwnd, lastExcludeFromCapture);
+
+    using clock = std::chrono::high_resolution_clock;
+    auto last_render_time = clock::now();
 
     while (!shouldExit)
     {
@@ -880,25 +589,50 @@ void OverlayThread()
         if (isAnyKeyPressed(config.button_open_overlay) & 0x1)
         {
             show_overlay = !show_overlay;
-
+            g_menuOpen = show_overlay; 
+            
+            LONG exStyle = GetWindowLong(g_hwnd, GWL_EXSTYLE);
             if (show_overlay)
             {
-                g_autoResizeEnabled = true;
-                EnsureOverlayInsideWorkArea(g_hwnd);
-                ShowWindow(g_hwnd, SW_SHOW);
+                SetWindowLong(g_hwnd, GWL_EXSTYLE, exStyle & ~WS_EX_TRANSPARENT);
                 SetForegroundWindow(g_hwnd);
             }
             else
             {
-                ShowWindow(g_hwnd, SW_HIDE);
+                SetWindowLong(g_hwnd, GWL_EXSTYLE, exStyle | WS_EX_TRANSPARENT);
             }
 
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
         }
 
-        if (!show_overlay)
+        bool should_render = false;
+        bool use_vsync = false; 
+
+        if (show_overlay)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            should_render = true;
+            use_vsync = true;
+        }
+        else if (config.show_crosshair)
+        {
+            auto now = clock::now();
+            double fps_target = config.crosshair_smart_color ? 60.0 : 1.0;
+            double frame_delay_ms = 1000.0 / fps_target;
+
+            std::chrono::duration<double, std::milli> elapsed = now - last_render_time;
+            if (elapsed.count() > frame_delay_ms)
+            {
+                should_render = true;
+                last_render_time = now;
+            }
+        }
+
+        if (!should_render)
+        {
+            if (show_overlay) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            else if (config.show_crosshair && config.crosshair_smart_color) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            else if (config.show_crosshair && !config.crosshair_smart_color) std::this_thread::sleep_for(std::chrono::milliseconds(32));
+            else std::this_thread::sleep_for(std::chrono::milliseconds(50));
             continue;
         }
 
@@ -906,95 +640,101 @@ void OverlayThread()
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
 
-        const float w = (float)overlayWidth;
-        const float h = (float)overlayHeight;
-        ApplyRuntimeUiScale(w, h);
-        const float sidebarWidth = std::clamp(w * 0.23f, w * 0.18f, w * 0.30f);
-
-        ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
-        ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_Always);
-        ImGui::PushStyleColor(ImGuiCol_WindowBg, IM_COL32(0, 0, 0, 0));
-        ImGui::Begin("##editor_root", nullptr,
-            ImGuiWindowFlags_NoDecoration |
-            ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoResize |
-            ImGuiWindowFlags_NoSavedSettings |
-            ImGuiWindowFlags_NoBringToFrontOnFocus |
-            ImGuiWindowFlags_NoScrollbar |
-            ImGuiWindowFlags_NoScrollWithMouse);
-        ImGui::PopStyleColor();
-
-        DrawMainPanelBackground(ImGui::GetWindowPos(), ImGui::GetWindowSize());
-
+        if (config.show_crosshair)
         {
-            std::lock_guard<std::mutex> lock(configMutex);
-
-            static int activeTab = 0;
-            const int tabCount = (int)(sizeof(kOverlayTabs) / sizeof(kOverlayTabs[0]));
-            if (activeTab < 0 || activeTab >= tabCount)
-                activeTab = 0;
-
-            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
-            ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(11, 11, 11, 245));
-            ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(255, 255, 255, 56));
-            ImGui::BeginChild("##options_nav", ImVec2(sidebarWidth, 0.0f), true,
-                ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_AlwaysVerticalScrollbar);
-
-            ImGui::TextUnformatted("SunOne Overlay");
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(143, 160, 182, 255));
-            ImGui::TextUnformatted("HOME to open/close");
-            ImGui::PopStyleColor();
-            ImGui::Dummy(ImVec2(0.0f, 2.0f));
-
-            const char* lastGroup = nullptr;
-            for (int i = 0; i < tabCount; ++i)
-            {
-                const char* group = kOverlayTabs[i].group;
-                if (!lastGroup || std::strcmp(lastGroup, group) != 0)
-                {
-                    if (lastGroup)
-                        ImGui::Dummy(ImVec2(0.0f, 2.0f));
-                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(165, 180, 199, 228));
-                    ImGui::TextUnformatted(group);
-                    ImGui::PopStyleColor();
-                }
-                if (DrawSidebarTabButton(kOverlayTabs[i].label, activeTab == i))
-                    activeTab = i;
-                lastGroup = group;
-            }
-            ImGui::EndChild();
-            ImGui::PopStyleColor(2);
-            ImGui::PopStyleVar();
-
-            ImGui::SameLine(0.0f, 6.0f);
-
-            float contentExtraW = 0.0f;
-            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
-            ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(12, 12, 12, 245));
-            ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(255, 255, 255, 56));
-            ImGui::BeginChild("##options_content", ImVec2(0.0f, 0.0f), true,
-                ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_AlwaysVerticalScrollbar);
-
-            ImGui::TextUnformatted(kOverlayTabs[activeTab].label);
-            ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(143, 160, 182, 255));
-            ImGui::TextWrapped("%s", kOverlayTabs[activeTab].description);
-            ImGui::PopStyleColor();
-            ImGui::Separator();
-
-            kOverlayTabs[activeTab].draw();
-
-            const float overflowX = ImGui::GetScrollMaxX();
-            contentExtraW = overflowX;
-            ImGui::EndChild();
-            ImGui::PopStyleColor(2);
-            ImGui::PopStyleVar();
-
-            TryAutoResizeOverlay(contentExtraW);
-
-            OverlayConfig_TrySave();
+            RenderActiveCrosshair(overlayWidth, overlayHeight);
         }
 
-        ImGui::End();
+        if (show_overlay)
+        {
+            ApplyRuntimeUiScale(BASE_OVERLAY_WIDTH, BASE_OVERLAY_HEIGHT);
+            const float sidebarWidth = std::clamp((float)BASE_OVERLAY_WIDTH * 0.23f, (float)BASE_OVERLAY_WIDTH * 0.18f, (float)BASE_OVERLAY_WIDTH * 0.30f);
+
+            ImGui::SetNextWindowPos(ImVec2((overlayWidth - BASE_OVERLAY_WIDTH) / 2.0f, (overlayHeight - BASE_OVERLAY_HEIGHT) / 2.0f), ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(BASE_OVERLAY_WIDTH, BASE_OVERLAY_HEIGHT), ImGuiCond_FirstUseEver);
+            ImGui::PushStyleColor(ImGuiCol_WindowBg, IM_COL32(0, 0, 0, 0));
+            
+            ImGui::Begin("##editor_root", nullptr,
+                ImGuiWindowFlags_NoDecoration |
+                ImGuiWindowFlags_NoBringToFrontOnFocus |
+                ImGuiWindowFlags_NoScrollbar |
+                ImGuiWindowFlags_NoScrollWithMouse);
+            ImGui::PopStyleColor();
+
+            ImVec2 windowPos = ImGui::GetWindowPos();
+            g_menuX = windowPos.x;
+            g_menuY = windowPos.y;
+            g_menuW = ImGui::GetWindowSize().x;
+            g_menuH = ImGui::GetWindowSize().y;
+
+            DrawMainPanelBackground(ImGui::GetWindowPos(), ImGui::GetWindowSize());
+
+            {
+                std::lock_guard<std::mutex> lock(configMutex);
+
+                static int activeTab = 0;
+                const int tabCount = (int)(sizeof(kOverlayTabs) / sizeof(kOverlayTabs[0]));
+                if (activeTab < 0 || activeTab >= tabCount)
+                    activeTab = 0;
+
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
+                ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(11, 11, 11, 245));
+                ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(255, 255, 255, 56));
+                ImGui::BeginChild("##options_nav", ImVec2(sidebarWidth, 0.0f), true,
+                    ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_AlwaysVerticalScrollbar);
+
+                ImGui::TextUnformatted("SunOne Overlay");
+                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(143, 160, 182, 255));
+                ImGui::TextUnformatted("HOME to open/close");
+                ImGui::PopStyleColor();
+                ImGui::Dummy(ImVec2(0.0f, 2.0f));
+
+                const char* lastGroup = nullptr;
+                for (int i = 0; i < tabCount; ++i)
+                {
+                    const char* group = kOverlayTabs[i].group;
+                    if (!lastGroup || std::strcmp(lastGroup, group) != 0)
+                    {
+                        if (lastGroup)
+                            ImGui::Dummy(ImVec2(0.0f, 2.0f));
+                        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(165, 180, 199, 228));
+                        ImGui::TextUnformatted(group);
+                        ImGui::PopStyleColor();
+                    }
+                    if (DrawSidebarTabButton(kOverlayTabs[i].label, activeTab == i))
+                        activeTab = i;
+                    lastGroup = group;
+                }
+                ImGui::EndChild();
+                ImGui::PopStyleColor(2);
+                ImGui::PopStyleVar();
+
+                ImGui::SameLine(0.0f, 6.0f);
+
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
+                ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(12, 12, 12, 245));
+                ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(255, 255, 255, 56));
+                ImGui::BeginChild("##options_content", ImVec2(0.0f, 0.0f), true,
+                    ImGuiWindowFlags_AlwaysUseWindowPadding | ImGuiWindowFlags_AlwaysVerticalScrollbar);
+
+                ImGui::TextUnformatted(kOverlayTabs[activeTab].label);
+                ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(143, 160, 182, 255));
+                ImGui::TextWrapped("%s", kOverlayTabs[activeTab].description);
+                ImGui::PopStyleColor();
+                ImGui::Separator();
+
+                kOverlayTabs[activeTab].draw();
+
+                ImGui::EndChild();
+                ImGui::PopStyleColor(2);
+                ImGui::PopStyleVar();
+
+                OverlayConfig_TrySave();
+            }
+
+            ImGui::End();
+        }
+
         ImGui::Render();
 
         const float clear_color_with_alpha[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
@@ -1002,11 +742,18 @@ void OverlayThread()
         g_pd3dDeviceContext->ClearRenderTargetView(g_mainRenderTargetView, clear_color_with_alpha);
         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 
-        HRESULT result = g_pSwapChain->Present(0, 0);
-        if (result == DXGI_STATUS_OCCLUDED || result == DXGI_ERROR_ACCESS_LOST)
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (use_vsync)
+        {
+            HRESULT result = g_pSwapChain->Present(1, 0);
+            if (result == DXGI_STATUS_OCCLUDED || result == DXGI_ERROR_ACCESS_LOST)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        else
+        {
+            HRESULT result = g_pSwapChain->Present(0, 0);
+            if (result == DXGI_STATUS_OCCLUDED || result == DXGI_ERROR_ACCESS_LOST)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
     }
 
     release_body_texture();
@@ -1020,13 +767,9 @@ void OverlayThread()
     ::UnregisterClass(_T("Chrome"), GetModuleHandle(NULL));
 }
 
-int APIENTRY _tWinMain(_In_ HINSTANCE hInstance,
-    _In_opt_ HINSTANCE hPrevInstance,
-    _In_ LPTSTR    lpCmdLine,
-    _In_ int       nCmdShow)
+int APIENTRY _tWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPTSTR lpCmdLine, _In_ int nCmdShow)
 {
     std::thread overlay(OverlayThread);
     overlay.join();
     return 0;
 }
-

--- a/sunone_aimbot_2/runtime/game_overlay_loop.cpp
+++ b/sunone_aimbot_2/runtime/game_overlay_loop.cpp
@@ -1544,6 +1544,22 @@ void gameOverlayRenderLoop()
             }
         }
 
+        // DYNAMIC FOV VISUALIZER
+        if (config.game_overlay_draw_frame) 
+        {
+            float cx = baseX + regionW * 0.5f;
+            float cy = baseY + regionH * 0.5f;
+            float currentFovW = static_cast<float>(config.fovX) * scaleX;
+            float currentFovH = static_cast<float>(config.fovY) * scaleY;
+            
+            // Draws a red box showing your exact active FOV
+            gameOverlayPtr->AddRect(
+                { cx - (currentFovW * 0.5f), cy - (currentFovH * 0.5f), currentFovW, currentFovH }, 
+                ARGB(255, 255, 50, 50), // Red color
+                1.5f // Thickness
+            );
+        }
+
         // BOXES
         if (config.game_overlay_draw_boxes && (!boxesCopy.empty() || !trackDebugCopy.empty()))
         {
@@ -1779,4 +1795,3 @@ void gameOverlayRenderLoop()
         gameOverlayPtr = nullptr;
     }
 }
-

--- a/sunone_aimbot_2/runtime/game_overlay_loop.cpp
+++ b/sunone_aimbot_2/runtime/game_overlay_loop.cpp
@@ -37,6 +37,7 @@ std::string g_lastIconPath;
 int g_iconImageId = 0;
 std::mutex g_iconMutex;
 }
+
 static void draw_target_correction_demo_game_overlay(Game_overlay* overlay, float centerX, float centerY)
 {
     if (!overlay)
@@ -148,7 +149,6 @@ struct AimSimulationState
     int lastMoveX = 0;
     int lastMoveY = 0;
 
-    // Controller state matched to current MouseThread::moveMousePivot + Kalman logic.
     aim::AimKalman2D ctrlKalman;
     aim::AimKalmanTelemetry ctrlKalmanTelemetry;
     bool kalmanSettingsInitialized = false;
@@ -160,7 +160,6 @@ struct AimSimulationState
     AimSimVec2 kalmanEstimatedTarget;
     AimSimVec2 kalmanVelocity;
 
-    // Keep WindMouse state between frames so simulation doesn't "reset" behavior.
     double windCarryX = 0.0;
     double windCarryY = 0.0;
     double windVelX = 0.0;
@@ -445,7 +444,6 @@ static void aim_sim_enqueue_move(AimSimulationState& s, double executeAtSec, int
     if (mx == 0 && my == 0)
         return;
 
-    // Match MouseThread queue behavior: small fixed queue with drop-oldest.
     constexpr size_t queueLimit = 5;
     if (s.queuedMoves.size() >= queueLimit)
         s.queuedMoves.pop_front();
@@ -1006,8 +1004,6 @@ static void draw_aim_sim_panel(
     }
 }
 
-
-
 void gameOverlayRenderLoop()
 {
     const int vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
@@ -1036,6 +1032,11 @@ void gameOverlayRenderLoop()
 #endif
     int lastDetectionVersion = -1;
     static AimSimulationState aimSimState;
+
+    static auto overlayStartTime = std::chrono::steady_clock::now();
+    static bool overlayReady = false;
+    static int lastMaxFps = -1;
+    static int lastExclude = -1;
 
     while (!gameOverlayShouldExit.load())
     {
@@ -1069,16 +1070,22 @@ void gameOverlayRenderLoop()
         {
             gameOverlayPtr = new Game_overlay();
             gameOverlayPtr->SetWindowBounds(0, 0, pw, ph);
-            gameOverlayPtr->SetMaxFPS(config.game_overlay_max_fps > 0 ? (unsigned)config.game_overlay_max_fps : 0);
-            gameOverlayPtr->SetExcludeFromCapture(config.overlay_exclude_from_capture);
             gameOverlayPtr->Start();
+            
+            overlayStartTime = std::chrono::steady_clock::now();
+            overlayReady = false;
+            lastMaxFps = -1; 
+            lastExclude = -1; 
         }
         else if (!gameOverlayPtr->IsRunning())
         {
             gameOverlayPtr->SetWindowBounds(0, 0, pw, ph);
-            gameOverlayPtr->SetMaxFPS(config.game_overlay_max_fps > 0 ? (unsigned)config.game_overlay_max_fps : 0);
-            gameOverlayPtr->SetExcludeFromCapture(config.overlay_exclude_from_capture);
             gameOverlayPtr->Start();
+            
+            overlayStartTime = std::chrono::steady_clock::now();
+            overlayReady = false;
+            lastMaxFps = -1; 
+            lastExclude = -1; 
         }
 
         if (!gameOverlayPtr || !gameOverlayPtr->IsRunning())
@@ -1087,8 +1094,28 @@ void gameOverlayRenderLoop()
             continue;
         }
 
-        gameOverlayPtr->SetMaxFPS(config.game_overlay_max_fps > 0 ? (unsigned)config.game_overlay_max_fps : 0);
-        gameOverlayPtr->SetExcludeFromCapture(config.overlay_exclude_from_capture);
+        if (!overlayReady)
+        {
+            auto now = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::milliseconds>(now - overlayStartTime).count() > 1500)
+            {
+                overlayReady = true;
+            }
+        }
+
+        if (overlayReady)
+        {
+            if (lastMaxFps != config.game_overlay_max_fps)
+            {
+                gameOverlayPtr->SetMaxFPS(config.game_overlay_max_fps > 0 ? (unsigned)config.game_overlay_max_fps : 0);
+                lastMaxFps = config.game_overlay_max_fps;
+            }
+            if (lastExclude != (config.overlay_exclude_from_capture ? 1 : 0))
+            {
+                gameOverlayPtr->SetExcludeFromCapture(config.overlay_exclude_from_capture);
+                lastExclude = config.overlay_exclude_from_capture ? 1 : 0;
+            }
+        }
 
         const int detRes = config.detection_resolution;
         if (detRes <= 0)
@@ -1141,88 +1168,112 @@ void gameOverlayRenderLoop()
             lockedTrackId = g_trackerLockedId;
         }
 
-        if (config.game_overlay_icon_enabled)
+        gameOverlayPtr->BeginFrame();
+
+        if (config.game_overlay_icon_enabled && overlayReady)
         {
             std::lock_guard<std::mutex> lk(g_iconMutex);
             if (config.game_overlay_icon_path != g_lastIconPath)
             {
-                if (g_iconImageId != 0)
-                {
-                    gameOverlayPtr->UnloadImage(g_iconImageId);
-                    g_iconImageId = 0;
-                }
-                g_lastIconPath = config.game_overlay_icon_path;
-                std::error_code fsErr;
-                std::filesystem::path p;
-                try
-                {
-                    p = std::filesystem::u8path(g_lastIconPath);
-                }
-                catch (const std::exception&)
-                {
-                    p = std::filesystem::path(g_lastIconPath);
-                }
-                const bool hasFile = !g_lastIconPath.empty() && p.has_filename() && std::filesystem::is_regular_file(p, fsErr);
-                if (fsErr)
-                {
-                    g_iconImageId = 0;
-                    g_iconLastError = "[GameOverlay] Failed to read icon path: " + g_lastIconPath + " (" + fsErr.message() + ")";
-                    std::cerr << g_iconLastError << std::endl;
-                }
-                else if (hasFile)
-                {
-                    const std::wstring wpath = p.wstring();
-                    g_iconLastError.clear();
+                static int failedIconRetries = 0;
+                static auto lastRetryTime = std::chrono::steady_clock::now();
+                auto now = std::chrono::steady_clock::now();
 
-                    UINT iw = 0, ih = 0;
-                    std::string verr;
-                    if (!IsValidImageFile(wpath, iw, ih, verr))
+                if (failedIconRetries == 0 || std::chrono::duration_cast<std::chrono::milliseconds>(now - lastRetryTime).count() > 1000)
+                {
+                    lastRetryTime = now;
+
+                    if (g_iconImageId != 0)
+                    {
+                        gameOverlayPtr->UnloadImage(g_iconImageId);
+                        g_iconImageId = 0;
+                    }
+
+                    std::error_code fsErr;
+                    std::filesystem::path p;
+                    try { p = std::filesystem::u8path(config.game_overlay_icon_path); }
+                    catch (...) { p = std::filesystem::path(config.game_overlay_icon_path); }
+
+                    const bool hasFile = !config.game_overlay_icon_path.empty() && p.has_filename() && std::filesystem::is_regular_file(p, fsErr);
+
+                    if (fsErr)
                     {
                         g_iconImageId = 0;
-                        g_iconLastError = "[GameOverlay] Invalid image '" + g_lastIconPath + "': " + verr;
+                        g_iconLastError = "[GameOverlay] Failed to read icon path: " + config.game_overlay_icon_path + " (" + fsErr.message() + ")";
                         std::cerr << g_iconLastError << std::endl;
+                        failedIconRetries = 6; 
+                    }
+                    else if (hasFile)
+                    {
+                        const std::wstring wpath = p.wstring();
+                        g_iconLastError.clear();
+
+                        UINT iw = 0, ih = 0;
+                        std::string verr;
+                        if (!IsValidImageFile(wpath, iw, ih, verr))
+                        {
+                            g_iconImageId = 0;
+                            g_iconLastError = "[GameOverlay] Invalid image '" + config.game_overlay_icon_path + "': " + verr;
+                            std::cerr << g_iconLastError << std::endl;
+                            failedIconRetries = 6; 
+                        }
+                        else
+                        {
+                            try
+                            {
+                                int id = gameOverlayPtr->LoadImageFromFile(wpath);
+                                if (id != 0)
+                                {
+                                    g_iconImageId = id;
+                                    g_lastIconPath = config.game_overlay_icon_path; 
+                                    failedIconRetries = 0;
+                                    std::cout << "[GameOverlay] Loaded icon (" << iw << "x" << ih << "): " << config.game_overlay_icon_path << std::endl;
+                                }
+                                else
+                                {
+                                    g_iconImageId = 0;
+                                    failedIconRetries++;
+                                    g_iconLastError = "[GameOverlay] Failed to load icon (loader returned 0): " + config.game_overlay_icon_path + " (Retry " + std::to_string(failedIconRetries) + "/5)";
+                                    std::cerr << g_iconLastError << std::endl;
+                                }
+                            }
+                            catch (const std::exception& e)
+                            {
+                                g_iconImageId = 0;
+                                g_iconLastError = std::string("[GameOverlay] Exception while loading icon: ") + e.what();
+                                std::cerr << g_iconLastError << std::endl;
+                                failedIconRetries = 6; 
+                            }
+                            catch (...)
+                            {
+                                g_iconImageId = 0;
+                                g_iconLastError = "[GameOverlay] Unknown exception while loading icon.";
+                                std::cerr << g_iconLastError << std::endl;
+                                failedIconRetries = 6; 
+                            }
+                        }
                     }
                     else
                     {
-                        try
-                        {
-                            int id = gameOverlayPtr->LoadImageFromFile(wpath);
-                            if (id != 0)
-                            {
-                                g_iconImageId = id;
-                                std::cout << "[GameOverlay] Loaded icon (" << iw << "x" << ih << "): " << g_lastIconPath << std::endl;
-                            }
-                            else
-                            {
-                                g_iconImageId = 0;
-                                g_iconLastError = "[GameOverlay] Failed to load icon (loader returned 0): " + g_lastIconPath;
-                                std::cerr << g_iconLastError << std::endl;
-                            }
-                        }
-                        catch (const std::exception& e)
-                        {
-                            g_iconImageId = 0;
-                            g_iconLastError = std::string("[GameOverlay] Exception while loading icon: ") + e.what();
-                            std::cerr << g_iconLastError << std::endl;
-                        }
-                        catch (...)
-                        {
-                            g_iconImageId = 0;
-                            g_iconLastError = "[GameOverlay] Unknown exception while loading icon.";
-                            std::cerr << g_iconLastError << std::endl;
-                        }
+                        g_iconImageId = 0;
+                        g_iconLastError = "[GameOverlay] Icon file not found: " + config.game_overlay_icon_path;
+                        std::cerr << g_iconLastError << std::endl;
+                        failedIconRetries = 6; 
+                    }
+
+                    if (failedIconRetries > 5)
+                    {
+                        g_lastIconPath = config.game_overlay_icon_path;
+                        failedIconRetries = 0;
                     }
                 }
-                else
-                {
-                    g_iconImageId = 0;
-                    g_iconLastError = "[GameOverlay] Icon file not found: " + g_lastIconPath;
-                    std::cerr << g_iconLastError << std::endl;
-                }
+            }
+            else
+            {
+                static int failedIconRetries = 0; 
+                failedIconRetries = 0;
             }
         }
-
-        gameOverlayPtr->BeginFrame();
 
 #ifdef USE_CUDA
         if (!config.depth_inference_enabled)
@@ -1508,7 +1559,6 @@ void gameOverlayRenderLoop()
         }
 #endif
 
-        // CAPTURE FRAME
         if (config.game_overlay_draw_frame)
         {
             int A = config.game_overlay_frame_a;
@@ -1544,7 +1594,6 @@ void gameOverlayRenderLoop()
             }
         }
 
-        // DYNAMIC FOV VISUALIZER
         if (config.game_overlay_draw_frame) 
         {
             float cx = baseX + regionW * 0.5f;
@@ -1552,15 +1601,13 @@ void gameOverlayRenderLoop()
             float currentFovW = static_cast<float>(config.fovX) * scaleX;
             float currentFovH = static_cast<float>(config.fovY) * scaleY;
             
-            // Draws a red box showing your exact active FOV
             gameOverlayPtr->AddRect(
                 { cx - (currentFovW * 0.5f), cy - (currentFovH * 0.5f), currentFovW, currentFovH }, 
-                ARGB(255, 255, 50, 50), // Red color
-                1.5f // Thickness
+                ARGB(255, 255, 50, 50), 
+                1.5f 
             );
         }
 
-        // BOXES
         if (config.game_overlay_draw_boxes && (!boxesCopy.empty() || !trackDebugCopy.empty()))
         {
             int A = config.game_overlay_box_a;
@@ -1635,7 +1682,6 @@ void gameOverlayRenderLoop()
             }
         }
 
-        // FUTURE POINTS
         if (config.game_overlay_draw_future && !futurePts.empty())
         {
             const int total = static_cast<int>(futurePts.size());
@@ -1667,7 +1713,6 @@ void gameOverlayRenderLoop()
             }
         }
 
-        // WIND DEBUG TAIL
         if (config.game_overlay_draw_wind_tail && windTailPts.size() > 1)
         {
             const size_t n = windTailPts.size();
@@ -1705,7 +1750,6 @@ void gameOverlayRenderLoop()
             );
         }
 
-        // ICONS
         if (config.game_overlay_icon_enabled && g_iconImageId != 0 && !boxesCopy.empty())
         {
             const int iconW = config.game_overlay_icon_width;
@@ -1719,7 +1763,7 @@ void gameOverlayRenderLoop()
             {
                 const auto& b = boxesCopy[i];
                 int cls = (i < classesCopy.size()) ? classesCopy[i] : -1;
-                // Class filter (-1 = all)
+                
                 if (wantedClass >= 0 && cls != wantedClass)
                 {
                     continue;

--- a/sunone_aimbot_2/runtime/mouse_thread_loop.cpp
+++ b/sunone_aimbot_2/runtime/mouse_thread_loop.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <optional>
 #include <vector>
+#include <random>
 
 #include "capture.h"
 #include "mouse.h"
@@ -12,45 +13,129 @@
 #include "ghub.h"
 
 extern GhubMouse* gHub;
+extern Arduino* arduinoSerial;
+extern KmboxNetConnection* kmboxNetSerial;
+extern KmboxAConnection* kmboxASerial;
+extern MakcuConnection* makcuSerial;
+
 #include "runtime/thread_loops.h"
 
 void createInputDevices();
 void assignInputDevices();
+
+std::chrono::steady_clock::time_point curve_start_time;
+std::chrono::steady_clock::time_point shoot_start_time;
+bool was_shooting = false;
+
+static double total_moved_x = 0.0;
+static float bezier_p1 = 0.0f;
+static float bezier_p2 = 0.0f;
+static double bezier_duration_sec = 2.0;
+static float remainder_x = 0.0f;
+static float remainder_y = 0.0f;
+
+float calculate_cubic_bezier_pos(float t, float p1, float p2)
+{
+    float u = 1.0f - t;
+    float term1 = 3.0f * u * u * t * p1;
+    float term2 = 3.0f * u * t * t * p2;
+    return term1 + term2;
+}
+
+void generate_new_curve()
+{
+    curve_start_time = std::chrono::steady_clock::now();
+    total_moved_x = 0.0;
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    float effective_width = 20.0f + (config.recoil_sway * 1.5f);
+    std::uniform_real_distribution<float> dist(-effective_width, effective_width);
+    bezier_p1 = dist(gen);
+    bezier_p2 = dist(gen);
+    if (std::abs(bezier_p1) < 5.0f) bezier_p1 = (bezier_p1 < 0) ? -5.0f : 5.0f;
+    if (std::abs(bezier_p2) < 5.0f) bezier_p2 = (bezier_p2 < 0) ? -5.0f : 5.0f;
+    float actual_speed_decimal = config.recoil_sway_speed * 0.0001f;
+    float speed_val = std::max(actual_speed_decimal, 0.00001f);
+    bezier_duration_sec = 1.0f / (speed_val * 600.0f);
+    if (bezier_duration_sec < 0.5) bezier_duration_sec = 0.5;
+    if (bezier_duration_sec > 3.0) bezier_duration_sec = 3.0;
+}
+
 void handleEasyNoRecoil(MouseThread& mouseThread)
 {
-    if (config.easynorecoil && shooting.load() && zooming.load())
+    bool currently_shooting = shooting.load() && zooming.load();
+    if (!currently_shooting)
+    {
+        was_shooting = false;
+        total_moved_x = 0.0;
+        remainder_x = 0.0f;
+        remainder_y = 0.0f;
+        return;
+    }
+    
+    auto now = std::chrono::steady_clock::now();
+    if (currently_shooting && !was_shooting)
+    {
+        shoot_start_time = now;
+        was_shooting = true;
+        generate_new_curve();
+    }
+    
+    double total_elapsed_ms = std::chrono::duration<double, std::milli>(now - shoot_start_time).count();
+    double curve_elapsed_sec = std::chrono::duration<double>(now - curve_start_time).count();
+    
+    if (curve_elapsed_sec > bezier_duration_sec)
+    {
+        generate_new_curve();
+        curve_elapsed_sec = 0.0;
+    }
+    
+    if (config.easynorecoil)
     {
         std::lock_guard<std::mutex> lock(mouseThread.input_method_mutex);
-        int recoil_compensation = static_cast<int>(config.easynorecoilstrength);
-
-        if (arduinoSerial)
+        
+        float move_y_float = config.recoil_pull_down_strength;
+        float standard_x_float = 0.0f;
+        
+        if (total_elapsed_ms >= static_cast<double>(config.recoil_pull_left_delay))
+            standard_x_float -= config.recoil_pull_left_strength;
+            
+        if (total_elapsed_ms >= static_cast<double>(config.recoil_pull_right_delay))
+            standard_x_float += config.recoil_pull_right_strength;
+            
+        float bezier_delta_x = 0.0f;
+        float t = static_cast<float>(curve_elapsed_sec / bezier_duration_sec);
+        if (t > 1.0f) t = 1.0f;
+        
+        float target_pos_x = calculate_cubic_bezier_pos(t, bezier_p1, bezier_p2);
+        bezier_delta_x = target_pos_x - static_cast<float>(total_moved_x);
+        total_moved_x += bezier_delta_x;
+        
+        float total_move_x = standard_x_float + bezier_delta_x + remainder_x;
+        float total_move_y = move_y_float + remainder_y;
+        
+        int final_x = static_cast<int>(total_move_x);
+        int final_y = static_cast<int>(total_move_y);
+        
+        remainder_x = total_move_x - final_x;
+        remainder_y = total_move_y - final_y;
+        
+        if (final_x != 0 || final_y != 0)
         {
-            arduinoSerial->move(0, recoil_compensation);
-        }
-        else if (gHub)
-        {
-            gHub->mouse_xy(0, recoil_compensation);
-        }
-        else if (kmboxNetSerial)
-        {
-            kmboxNetSerial->move(0, recoil_compensation);
-        }
-        else if (kmboxASerial)
-        {
-            kmboxASerial->move(0, recoil_compensation);
-        }
-        else if (makcuSerial)
-        {
-            makcuSerial->move(0, recoil_compensation);
-        }
-        else
-        {
-            INPUT input = { 0 };
-            input.type = INPUT_MOUSE;
-            input.mi.dx = 0;
-            input.mi.dy = recoil_compensation;
-            input.mi.dwFlags = MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
-            SendInput(1, &input, sizeof(INPUT));
+            if (arduinoSerial) arduinoSerial->move(final_x, final_y);
+            else if (gHub) gHub->mouse_xy(final_x, final_y);
+            else if (kmboxNetSerial) kmboxNetSerial->move(final_x, final_y);
+            else if (kmboxASerial) kmboxASerial->move(final_x, final_y);
+            else if (makcuSerial) makcuSerial->move(final_x, final_y);
+            else 
+            {
+                INPUT input = { 0 };
+                input.type = INPUT_MOUSE;
+                input.mi.dx = final_x;
+                input.mi.dy = final_y;
+                input.mi.dwFlags = MOUSEEVENTF_MOVE;
+                SendInput(1, &input, sizeof(INPUT));
+            }
         }
     }
 }
@@ -210,5 +295,3 @@ void mouseThreadFunction(MouseThread& mouseThread)
         mouseThread.checkAndResetPredictions();
     }
 }
-
-

--- a/sunone_aimbot_2/runtime/mouse_thread_loop.cpp
+++ b/sunone_aimbot_2/runtime/mouse_thread_loop.cpp
@@ -149,6 +149,9 @@ void mouseThreadFunction(MouseThread& mouseThread)
     std::optional<AimbotTarget> activeTarget;
     auto lastTrackerUpdate = std::chrono::steady_clock::time_point::min();
 
+    bool last_zoom_state = false;
+    float last_hipfire_smooth = -1.0f; 
+
     while (!shouldExit)
     {
         bool hasNewDetection = false;
@@ -179,28 +182,60 @@ void mouseThreadFunction(MouseThread& mouseThread)
             input_method_changed.store(false);
         }
 
-        if (detection_resolution_changed.load())
+        bool current_zoom = zooming.load();
+        bool zoom_changed = (current_zoom != last_zoom_state);
+
+        if (detection_resolution_changed.load() || zoom_changed || std::abs(config.hipfire_smooth - last_hipfire_smooth) > 0.001f)
         {
             {
                 std::lock_guard<std::mutex> cfgLock(configMutex);
+                
+                int active_fov_x = config.fovX_hipfire;
+                int active_fov_y = config.fovY_hipfire;
+                float active_min_speed = config.minSpeedMultiplier;
+                float active_max_speed = config.maxSpeedMultiplier;
+                
+                if (config.enable_dynamic_fov) 
+                {
+                    if (current_zoom) {
+                        active_fov_x = config.fovX_ads;
+                        active_fov_y = config.fovY_ads;
+                    } else {
+                        active_min_speed *= config.hipfire_smooth;
+                        active_max_speed *= config.hipfire_smooth;
+                    }
+                }
+                else 
+                {
+                    active_fov_x = config.fovX_ads;
+                    active_fov_y = config.fovY_ads;
+                }
+
+                config.fovX = active_fov_x;
+                config.fovY = active_fov_y;
+
                 mouseThread.updateConfig(
                     config.detection_resolution,
-                    config.fovX,
-                    config.fovY,
-                    config.minSpeedMultiplier,
-                    config.maxSpeedMultiplier,
+                    active_fov_x,
+                    active_fov_y,
+                    active_min_speed,
+                    active_max_speed,
                     config.predictionInterval,
                     config.auto_shoot,
                     config.bScope_multiplier
                 );
             }
+            
             targetTracker.reset();
             {
                 std::lock_guard<std::mutex> lk(g_trackerDebugMutex);
                 g_trackerDebugTracks.clear();
                 g_trackerLockedId = -1;
             }
+            
             detection_resolution_changed.store(false);
+            last_zoom_state = current_zoom; 
+            last_hipfire_smooth = config.hipfire_smooth;
         }
 
         if (hasNewDetection)


### PR DESCRIPTION
**Standalone crosshair overlay feature into SunOne 2.**

Core Technical Changes:

    Rendering Engine Update: Replaced DirectComposition with standard DXGI 1.2 swap chain creation (CreateSwapChainForHwnd). This was necessary because DirectComposition does not support LWA_COLORKEY transparency, which is required for the crosshair to render on a click-through background.

    Window Management: Updated the OS window to be permanently fullscreen and click-through. This ensures the crosshair remains perfectly centered regardless of monitor resolution, while the LWA_COLORKEY ensures 0% input latency interference with the game.

    Native ImGui Dragging: Since the OS window is now fullscreen, native Windows window-dragging is disabled. I have implemented native ImGui dragging for the menu so users can still reposition the UI anywhere on their screen.

    Isolated Config Saving: ImGui window positions are now saved to sunone_ui_layout.ini. This prevents ImGui's internal text formatter from overwriting or corrupting the primary config.ini aimbot settings.

    Settings Persistence: Bound all crosshair UI elements (Hue, Saturation, Scale, Smart Color, etc.) to the OverlayConfig_MarkDirty() system to ensure settings are saved instantly when modified.

    Console Toggle: Restored the "Show Console Window" checkbox in the Debug menu using ShowWindow(GetConsoleWindow()), with the preference saved to and loaded from config.ini.
    
**Advanced recoil compensation and bezier-curve-based humanizer (sway) logic**    

    Recoil Humanization: Implemented a cubic Bezier curve randomizer (calculate_cubic_bezier_pos / generate_new_curve) to simulate natural, human-like weapon sway during sustained fire.
    
    UI Implementation: Updated the Mouse UI section with sliders for Recoil Strength, Delayed Left/Right Pulls, and Sway Speed/Amount.
    
**Dynamic FOV Scaling, Hipfire Smoothing & FOV Visualizer**

  Dynamic FOV Switching (mouse_thread_loop.cpp): The aimbot now actively listens to the zooming state. When the user aims down sights, the thread mathematically snaps the active tracking area from fovX_hipfire to fovX_ads (and vice-versa).

 Hipfire Speed Smoothing: Added a hipfire_smooth multiplier. When firing from the hip (not zooming), the aimbot scales down minSpeedMultiplier and maxSpeedMultiplier by this factor to prevent erratic over-flicking on close targets, while preserving fast tracking during ADS.
 
 **Resolve overlay startup race conditions**

  Addresses two startup synchronization issues that occur when the overlay attempts to initialize assets and modify window properties before the Desktop Window Manager (DWM) and DirectX context are fully established.