### PR TITLE
Fix capture FPS drop when overlays are closed

### DIFF
--- a/sunone_aimbot_2/capture/capture.cpp
+++ b/sunone_aimbot_2/capture/capture.cpp
@@ -597,19 +597,32 @@ void captureThread(int CAPTURE_WIDTH, int CAPTURE_HEIGHT)
         setCaptureUnavailable();
 
         TimerResolutionGuard timerResolution;
+        // Always request 1 ms timer resolution for the lifetime of the capture thread.
+        // The loop performs short sleeps or yields in the "no new frame" backoff paths
+        // (when capture_fps == 0 / unlimited) to avoid 100% CPU spin while waiting for
+        // Duplication API / WinRT to deliver a present. It also needs precise sleeps for
+        // the frame limiter when a cap is active.
+        // Without timeBeginPeriod(1), these round up to the default Windows timer
+        // resolution (~15.6 ms), throttling the capture loop (and reported captureFps)
+        // unless something else in the process (the overlay/GUI D3D presents + short
+        // sleep loops) has already bumped the resolution as a side effect.
+        timerResolution.Enable();
+
         std::optional<std::chrono::steady_clock::duration> frameDuration;
         auto updateFrameDuration = [&](int captureFpsSetting)
         {
             if (captureFpsSetting > 0)
             {
-                timerResolution.Enable();
                 const auto frameMs = std::chrono::duration<double, std::milli>(1000.0 / captureFpsSetting);
                 frameDuration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(frameMs);
             }
             else
             {
-                timerResolution.Disable();
                 frameDuration.reset();
+                // Do NOT Disable() the timer resolution here. The 1 ms backoff sleeps
+                // (see the four sites below that check !frameDuration.has_value()) and
+                // the applyFrameLimiter pacing still require it when running unlimited.
+                // The guard's destructor will call timeEndPeriod(1) on thread exit.
             }
         };
         updateFrameDuration(currentCfg.capture_fps);


### PR DESCRIPTION
## Summary

Fixes a capture/effective detection FPS drop that occurs when both the ImGui options overlay and the in-game overlay are closed, especially when `capture_fps = 0` / unlimited.

The change is intentionally small and scoped to `sunone_aimbot_2/capture/capture.cpp`.

## Bug

The capture thread currently requests high-resolution Windows timer timing only when a positive capture FPS cap is configured:

- `capture_fps > 0`: calls `timeBeginPeriod(1)` through `TimerResolutionGuard::Enable()` and uses `frameDuration` for pacing.
- `capture_fps == 0`: disables the timer guard and clears `frameDuration`.

However, the unlimited path still uses short backoff waits when no fresh frame is available:

- WinRT target/window wait path.
- Missing capturer recovery path.
- CUDA/DDA no-present direct path.
- CPU `GetNextFrameCpu()` empty-frame path.

Those paths use `sleep_for(1ms)`, `sleep_for(10ms)`, or `yield()` to avoid CPU spin. On Windows, without `timeBeginPeriod(1)`, a requested 1 ms sleep can round up to the default ~15.6 ms system timer granularity. That unintentionally throttles the capture loop and lowers reported `captureFps` / frame delivery rate.

Opening the GUI or game overlay can mask the problem because the overlay render/present loops and short sleeps may raise effective timer resolution elsewhere in the process. That made capture FPS appear correct only while an overlay was open.

## Fix

- Enable `TimerResolutionGuard` once for the lifetime of `captureThread`.
- Remove the per-`capture_fps > 0` `Enable()` call.
- Stop calling `Disable()` when `capture_fps == 0`.
- Keep existing backoff and frame limiter behavior unchanged.
- Keep cleanup unchanged: the guard destructor still calls `timeEndPeriod(1)` when the capture thread exits.

This makes both capped and unlimited capture modes use accurate short sleeps independently of whether the overlays are open.

## Why this is the right owner

`capture.cpp` is the only project source file using `timeBeginPeriod` / `timeEndPeriod`. The root cause is capture-thread timing policy, not overlay behavior. The overlays only made the bug less visible by changing process timing side effects.

## Verification

Verified locally before opening this PR:

```powershell
.\tools\build_dml.ps1 -Configuration Release -OpenCvAlreadyBuilt true -DownloadOrUpdateNeeded true -NonInteractive
.\tools\build_cuda.ps1 -Configuration Release -OpenCvAlreadyBuilt true -DownloadOrUpdateNeeded false -SkipOpenCvBuild -NonInteractive
```

Both DML and CUDA Release builds completed successfully.

Also checked the upstream PR diff range:

```powershell
git diff --stat origin/main..nanobyte/main
git diff --name-status origin/main..nanobyte/main
```

Result: only `sunone_aimbot_2/capture/capture.cpp` changed.